### PR TITLE
UHF-1526: Allow menu links to be added from entity forms

### DIFF
--- a/helfi_tpr.info.yml
+++ b/helfi_tpr.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - text
   - address
   - link
+  - menu_link_content
   - migrate
   - content_translation
   - language

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -423,3 +423,19 @@ function helfi_tpr_update_8018() : void {
     ->setTranslatable(FALSE);
   $manager->installFieldStorageDefinition('phone', 'tpr_unit', 'helfi_tpr', $field);
 }
+
+/**
+ * Installs 'menu_link' field.
+ */
+function helfi_tpr_update_8020() : void {
+  $menu_link = BaseFieldDefinition::create('entity_reference')
+    ->setLabel(new TranslatableMarkup('Menu link'))
+    ->setSettings([
+      'target_type' => 'menu_link_content',
+    ])
+    ->setRevisionable(FALSE)
+    ->setTranslatable(TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('menu_link', 'tpr_unit', 'helfi_tpr', $menu_link);
+}

--- a/src/Entity/Form/ContentEntityForm.php
+++ b/src/Entity/Form/ContentEntityForm.php
@@ -7,6 +7,8 @@ namespace Drupal\helfi_tpr\Entity\Form;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\ContentEntityForm as CoreContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Menu\MenuParentFormSelectorInterface;
+use Drupal\helfi_api_base\Entity\Form\MenuLinkFormTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -16,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ContentEntityForm extends CoreContentEntityForm {
 
+  use MenuLinkFormTrait;
+
   /**
    * The date formatter service.
    *
@@ -24,11 +28,19 @@ class ContentEntityForm extends CoreContentEntityForm {
   protected DateFormatterInterface $dateFormatter;
 
   /**
+   * The menu parent form selector.
+   *
+   * @var \Drupal\Core\Menu\MenuParentFormSelectorInterface
+   */
+  protected MenuParentFormSelectorInterface $menuParentSelector;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     $instance = parent::create($container);
     $instance->dateFormatter = $container->get('date.formatter');
+    $instance->menuParentSelector = $container->get('menu.parent_form_selector');
     return $instance;
   }
 
@@ -50,6 +62,10 @@ class ContentEntityForm extends CoreContentEntityForm {
     // TPR entities are unpublished by default and might not have any
     // translations, leaving users unable to un/publish given content.
     $controller->entityFormAlter($form, $form_state, $entity);
+
+    if ($entity->hasField('menu_link')) {
+      $form = $this->attachMenuLinkForm($form, $form_state);
+    }
 
     return $form;
   }

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -237,7 +237,6 @@ class Unit extends TprEntityBase {
       ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
-
     $fields['call_charge_info'] = BaseFieldDefinition::create('text_long')
       ->setTranslatable(TRUE)
       ->setRevisionable(FALSE)
@@ -247,9 +246,7 @@ class Unit extends TprEntityBase {
       ])
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
-
     $fields['address_postal'] = static::createStringField('Address postal');
-
     $fields['latitude'] = static::createStringField('Latitude')
       ->setTranslatable(FALSE);
     $fields['longitude'] = static::createStringField('Longitude')
@@ -264,7 +261,6 @@ class Unit extends TprEntityBase {
         'label' => 'hidden',
         'type' => 'service_map_embed',
       ]);
-
     $fields['services'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(new TranslatableMarkup('Services'))
       ->setSettings([
@@ -277,6 +273,13 @@ class Unit extends TprEntityBase {
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
+    $fields['menu_link'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(new TranslatableMarkup('Menu link'))
+      ->setSettings([
+        'target_type' => 'menu_link_content',
+      ])
+      ->setRevisionable(FALSE)
+      ->setTranslatable(TRUE);
 
     return $fields;
   }

--- a/tests/src/Functional/MigrationTestBase.php
+++ b/tests/src/Functional/MigrationTestBase.php
@@ -22,6 +22,7 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
     'media',
     'block',
     'readonly_field_widget',
+    'menu_link_content',
     'media_library',
     'entity',
     'helfi_tpr',

--- a/tests/src/Functional/MigrationTestBase.php
+++ b/tests/src/Functional/MigrationTestBase.php
@@ -22,7 +22,6 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
     'media',
     'block',
     'readonly_field_widget',
-    'menu_link_content',
     'media_library',
     'entity',
     'helfi_tpr',

--- a/tests/src/Functional/UnitMenuLinkTest.php
+++ b/tests/src/Functional/UnitMenuLinkTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\helfi_tpr\Traits\UnitMigrateTrait;
+
+/**
+ * Tests unit revisions.
+ *
+ * @group helfi_tpr
+ */
+class UnitMenuLinkTest extends MigrationTestBase {
+
+  use UnitMigrateTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'menu_link_content',
+    'menu_ui',
+  ];
+
+  private function assertMenuLink(string $expected_link, string $language, bool $expected) : void {
+    // Make sure link is disabled by default.
+    $this->drupalGet('/admin/structure/menu/manage/main', [
+      'query' => ['language' => $language],
+    ]);
+    $this->assertSession()->linkExists($expected_link);
+    $element = $this->getSession()->getPage()->find('css', '.checkbox.menu-enabled input[type="checkbox"]');
+    $this->assertNotNull($element);
+
+    if ($expected) {
+      $this->assertTrue($element->isChecked());
+    }
+    else {
+      $this->assertTrue(!$element->isChecked());
+    }
+  }
+
+  /**
+   * Tests menu link creation.
+   */
+  public function testMenuLink() : void {
+    $role = $this->drupalCreateRole([
+      'administer menu',
+    ]);
+    $this->drupalLogin($this->privilegedAccount);
+
+    $units = [
+      [
+        'id' => 999,
+        'name_fi' => 'Name fi',
+        'name_sv' => 'Name sv',
+        'call_charge_info_fi' => 'Charge fi',
+        'call_charge_info_sv' => 'Charge sv',
+        'modified_time' => '2015-05-16T20:01:01',
+      ],
+    ];
+    $this->runMigrate($units);
+
+    foreach (['fi', 'sv'] as $language) {
+      $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 999]), [
+        'query' => ['language' => $language],
+      ]);
+      $this->assertSession()->statusCodeEquals(200);
+      // Make sure we can't see menu without permission.
+      $this->assertSession()->fieldNotExists('menu[enabled]');
+    }
+
+    // Add role to allow our user to edit menus.
+    $this->privilegedAccount->addRole($role);
+    $this->privilegedAccount->save();
+
+    foreach (['fi', 'sv'] as $language) {
+      $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 999]), [
+        'query' => ['language' => $language],
+      ]);
+      // Make sure menu link is not enabled by default.
+      $this->assertSession()->checkboxNotChecked('menu[enabled]');
+
+      $this->submitForm([
+        'menu[enabled]' => TRUE,
+        'menu[title]' => "Menu link $language",
+      ], 'Save');
+
+      $this->assertSession()->checkboxChecked('menu[enabled]');
+      $this->assertSession()->fieldValueEquals('menu[title]', "Menu link $language");
+
+      // Make sure link is disabled by default.
+      $this->assertMenuLink("Menu link $language", $language, FALSE);
+
+      // Make sure publishing entity also publishes the menu link.
+      $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 999]), [
+        'query' => ['language' => $language],
+      ]);
+      $this->submitForm([
+        'content_translation[status]' => TRUE,
+      ], 'Save');
+      $this->assertMenuLink("Menu link $language", $language, TRUE);
+    }
+  }
+
+}

--- a/tests/src/Functional/UnitMenuLinkTest.php
+++ b/tests/src/Functional/UnitMenuLinkTest.php
@@ -24,7 +24,17 @@ class UnitMenuLinkTest extends MigrationTestBase {
     'menu_ui',
   ];
 
-  private function assertMenuLink(string $expected_link, string $language, bool $expected) : void {
+  /**
+   * Asserts that given menu link exists and is enabled or disabled.
+   *
+   * @param string $expected_link
+   *   The expected link label.
+   * @param string $language
+   *   The language.
+   * @param bool $is_checked
+   *   Whether the checkbox is expected to be checked or not.
+   */
+  private function assertMenuLink(string $expected_link, string $language, bool $is_checked) : void {
     // Make sure link is disabled by default.
     $this->drupalGet('/admin/structure/menu/manage/main', [
       'query' => ['language' => $language],
@@ -33,7 +43,7 @@ class UnitMenuLinkTest extends MigrationTestBase {
     $element = $this->getSession()->getPage()->find('css', '.checkbox.menu-enabled input[type="checkbox"]');
     $this->assertNotNull($element);
 
-    if ($expected) {
+    if ($is_checked) {
       $this->assertTrue($element->isChecked());
     }
     else {

--- a/tests/src/Functional/UnitMenuLinkTest.php
+++ b/tests/src/Functional/UnitMenuLinkTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\Url;
 use Drupal\Tests\helfi_tpr\Traits\UnitMigrateTrait;
 
 /**
- * Tests unit revisions.
+ * Tests menu link creation from unit entity form.
  *
  * @group helfi_tpr
  */
@@ -35,7 +35,6 @@ class UnitMenuLinkTest extends MigrationTestBase {
    *   Whether the checkbox is expected to be checked or not.
    */
   private function assertMenuLink(string $expected_link, string $language, bool $is_checked) : void {
-    // Make sure link is disabled by default.
     $this->drupalGet('/admin/structure/menu/manage/main', [
       'query' => ['language' => $language],
     ]);

--- a/tests/src/Kernel/MigrationTestBase.php
+++ b/tests/src/Kernel/MigrationTestBase.php
@@ -24,6 +24,7 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
     'helfi_tpr',
     'media',
     'telephone',
+    'menu_link_content',
   ];
 
   /**
@@ -33,6 +34,7 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
     parent::setUp();
 
     $entity_types = [
+      'menu_link_content',
       'tpr_unit',
       'tpr_service',
       'tpr_errand_service',


### PR DESCRIPTION
`composer update drupal/helfi_api_base`
`composer require drupal/helfi_tpr:dev-UHF-1526`

Make sure menu links can be added straight from the unit page.