### PR TITLE
UHF-1772 Missing integration overviews

### DIFF
--- a/config/install/system.action.tpr_errand_service_publish_action.yml
+++ b/config/install/system.action.tpr_errand_service_publish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_errand_service_publish_action
+label: 'Publish errand service'
+type: tpr_errand_service
+plugin: entity:publish_action:tpr_errand_service
+configuration: {  }

--- a/config/install/system.action.tpr_errand_service_unpublish_action.yml
+++ b/config/install/system.action.tpr_errand_service_unpublish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_errand_service_unpublish_action
+label: 'Unpublish errand service'
+type: tpr_errand_service
+plugin: entity:unpublish_action:tpr_errand_service
+configuration: {  }

--- a/config/install/system.action.tpr_service_channel_publish_action.yml
+++ b/config/install/system.action.tpr_service_channel_publish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_service_channel_publish_action
+label: 'Publish service channel'
+type: tpr_service_channel
+plugin: entity:publish_action:tpr_service_channel
+configuration: {  }

--- a/config/install/system.action.tpr_service_channel_unpublish_action.yml
+++ b/config/install/system.action.tpr_service_channel_unpublish_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: tpr_service_channel_unpublish_action
+label: 'Unpublish service channel'
+type: tpr_service_channel
+plugin: entity:unpublish_action:tpr_service_channel
+configuration: {  }

--- a/config/language/fi/views.view.tpr_errand_service_list.yml
+++ b/config/language/fi/views.view.tpr_errand_service_list.yml
@@ -1,0 +1,57 @@
+label: 'TPR Asiointipalvelut'
+display:
+  default:
+    display_options:
+      empty:
+        area:
+          content:
+            value: 'Asiointipalveluja ei löytynyt.'
+            format: plain_text
+      exposed_form:
+        options:
+          submit_button: Käytä
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      pager:
+        options:
+          tags:
+            previous: '‹ Edellinen'
+            next: 'Seuraava ›'
+            first: '« Ensimmäinen'
+            last: 'Viimeinen »'
+          expose:
+            items_per_page_label: 'Merkintöjä sivua kohti'
+            items_per_page_options_all_label: '- Kaikki -'
+      fields:
+        name:
+          label: Nimi
+        langcode:
+          label: Kieli
+        content_translation_status:
+          label: Tila
+          settings:
+            format_custom_true: Julkaistu
+            format_custom_false: Julkaisematon
+        content_translation_changed:
+          label: Päivitetty
+        operations:
+          label: Toimenpiteet
+        tpr_errand_service_bulk_form:
+          label: Massapäivitys
+          action_title: Toiminto
+      title: 'TPR Asiointipalvelut'
+      header:
+        result:
+          content: 'Näytetään @start - @end / @total'
+      filters:
+        combine:
+          expose:
+            label: Etsi
+        langcode:
+          expose:
+            label: Kieli
+    display_title: Oletus
+  page_1:
+    display_title: Sivu

--- a/config/language/fi/views.view.tpr_service_channel_list.yml
+++ b/config/language/fi/views.view.tpr_service_channel_list.yml
@@ -1,0 +1,57 @@
+label: 'TPR Palvelukanavat'
+display:
+  default:
+    display_options:
+      empty:
+        area:
+          content:
+            value: 'Palvelukanavia ei löytynyt.'
+            format: plain_text
+      exposed_form:
+        options:
+          submit_button: Käytä
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      pager:
+        options:
+          tags:
+            previous: '‹ Edellinen'
+            next: 'Seuraava ›'
+            first: '« Ensimmäinen'
+            last: 'Viimeinen »'
+          expose:
+            items_per_page_label: 'Merkintöjä sivua kohti'
+            items_per_page_options_all_label: '- Kaikki -'
+      fields:
+        name:
+          label: Nimi
+        langcode:
+          label: Kieli
+        content_translation_status:
+          label: Tila
+          settings:
+            format_custom_true: Julkaistu
+            format_custom_false: Julkaisematon
+        content_translation_changed:
+          label: Päivitetty
+        operations:
+          label: Toimenpiteet
+        tpr_service_channel_bulk_form:
+          label: Massapäivitys
+          action_title: Toiminto
+      title: 'TPR Palvelukanavat'
+      header:
+        result:
+          content: 'Näytetään @start - @end / @total'
+      filters:
+        combine:
+          expose:
+            label: Etsi
+        langcode:
+          expose:
+            label: Kieli
+    display_title: Oletus
+  page_1:
+    display_title: Sivu

--- a/config/optional/views.view.tpr_errand_service_list.yml
+++ b/config/optional/views.view.tpr_errand_service_list.yml
@@ -1,0 +1,734 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - user
+id: tpr_errand_service_list
+label: 'TPR errand service list'
+module: views
+description: ''
+tag: ''
+base_table: tpr_errand_service_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Default
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access remote entities overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            id: id
+            name: name
+            langcode: langcode
+            content_translation_status: content_translation_status
+            content_translation_changed: content_translation_changed
+            operations: operations
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            content_translation_status:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            content_translation_changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: content_translation_status
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        tpr_errand_service_bulk_form:
+          id: tpr_errand_service_bulk_form
+          table: tpr_errand_service
+          field: tpr_errand_service_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: tpr_errand_service
+          plugin_id: bulk_form
+        id:
+          id: id
+          table: tpr_errand_service_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_errand_service
+          entity_field: id
+          plugin_id: field
+        name:
+          id: name
+          table: tpr_errand_service_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_errand_service
+          entity_field: name
+          plugin_id: field
+        langcode:
+          id: langcode
+          table: tpr_errand_service_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_errand_service
+          entity_field: langcode
+          plugin_id: field
+        content_translation_status:
+          id: content_translation_status
+          table: tpr_errand_service_field_data
+          field: content_translation_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_errand_service
+          entity_field: content_translation_status
+          plugin_id: field
+        content_translation_changed:
+          id: content_translation_changed
+          table: tpr_errand_service_field_data
+          field: content_translation_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: long
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_errand_service
+          entity_field: content_translation_changed
+          plugin_id: field
+        operations:
+          id: operations
+          table: tpr_errand_service
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+          entity_type: tpr_errand_service
+          plugin_id: entity_operations
+      filters:
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: allwords
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              admin: '0'
+              content_producer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            id: id
+            name: name
+          plugin_id: combine
+        langcode:
+          id: langcode
+          table: tpr_errand_service_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            fi: fi
+            sv: sv
+            en: en
+            ru: ru
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              admin: '0'
+              content_producer: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: tpr_errand_service
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        content_translation_changed:
+          id: content_translation_changed
+          table: tpr_errand_service_field_data
+          field: content_translation_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: tpr_errand_service
+          entity_field: content_translation_changed
+          plugin_id: date
+      title: 'TPR Errand Services'
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          content: 'Displaying @start - @end of @total'
+          plugin_id: result
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No results found.'
+            format: plain_text
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/integrations/tpr-errand-service
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/optional/views.view.tpr_service_channel_list.yml
+++ b/config/optional/views.view.tpr_service_channel_list.yml
@@ -1,0 +1,734 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - user
+id: tpr_service_channel_list
+label: 'TPR service channel list'
+module: views
+description: ''
+tag: ''
+base_table: tpr_service_channel_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Default
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access remote entities overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            id: id
+            name: name
+            langcode: langcode
+            content_translation_status: content_translation_status
+            content_translation_changed: content_translation_changed
+            operations: operations
+          info:
+            id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            langcode:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            content_translation_status:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            content_translation_changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: content_translation_status
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        tpr_service_channel_bulk_form:
+          id: tpr_service_channel_bulk_form
+          table: tpr_service_channel
+          field: tpr_service_channel_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: tpr_service_channel
+          plugin_id: bulk_form
+        id:
+          id: id
+          table: tpr_service_channel_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_service_channel
+          entity_field: id
+          plugin_id: field
+        name:
+          id: name
+          table: tpr_service_channel_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_service_channel
+          entity_field: name
+          plugin_id: field
+        langcode:
+          id: langcode
+          table: tpr_service_channel_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Language
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: language
+          settings:
+            link_to_entity: false
+            native_language: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_service_channel
+          entity_field: langcode
+          plugin_id: field
+        content_translation_status:
+          id: content_translation_status
+          table: tpr_service_channel_field_data
+          field: content_translation_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_service_channel
+          entity_field: content_translation_status
+          plugin_id: field
+        content_translation_changed:
+          id: content_translation_changed
+          table: tpr_service_channel_field_data
+          field: content_translation_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: long
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: tpr_service_channel
+          entity_field: content_translation_changed
+          plugin_id: field
+        operations:
+          id: operations
+          table: tpr_service_channel
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+          entity_type: tpr_service_channel
+          plugin_id: entity_operations
+      filters:
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: allwords
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              admin: '0'
+              content_producer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            id: id
+            name: name
+          plugin_id: combine
+        langcode:
+          id: langcode
+          table: tpr_service_channel_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            fi: fi
+            sv: sv
+            en: en
+            ru: ru
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              admin: '0'
+              content_producer: '0'
+            reduce: true
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: tpr_service_channel
+          entity_field: langcode
+          plugin_id: language
+      sorts:
+        content_translation_changed:
+          id: content_translation_changed
+          table: tpr_service_channel_field_data
+          field: content_translation_changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          entity_type: tpr_service_channel
+          entity_field: content_translation_changed
+          plugin_id: date
+      title: 'TPR Service Channels'
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          content: 'Displaying @start - @end of @total'
+          plugin_id: result
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No results found.'
+            format: plain_text
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/integrations/tpr-service-channel
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -425,3 +425,41 @@ function helfi_tpr_update_8024() : void {
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('menu_link_content', 'tpr_service', 'helfi_tpr', $field);
 }
+
+/**
+ * Install tpr_errand_service and tpr_service_channel views.
+ */
+function helfi_tpr_update_8025() : void {
+  $config_storage = \Drupal::service('config.storage');
+  $config_factory = \Drupal::configFactory();
+  $uuid_service = \Drupal::service('uuid');
+
+  // Create file storages.
+  $config_path = drupal_get_path('module', 'helfi_tpr').'/config/install';
+  $config_source = new FileStorage($config_path);
+  $optional_config_path = drupal_get_path('module', 'helfi_tpr') . '/config/optional';
+  $optional_config_source = new FileStorage($optional_config_path);
+  $language_config_path = drupal_get_path('module', 'helfi_tpr') . '/config/language/fi';
+  $language_config_source = new FileStorage($language_config_path);
+
+  // Add new config: publish and unpublish actions for 'Errand service' and 'Service channel'.
+  $actions = [
+    'system.action.tpr_errand_service_publish_action',
+    'system.action.tpr_errand_service_unpublish_action',
+    'system.action.tpr_service_channel_publish_action',
+    'system.action.tpr_service_channel_unpublish_action',
+  ];
+  foreach ($actions as $action) {
+    $config_storage->write($action, $config_source->read($action));
+    $config_factory->getEditable($action)->set('uuid', $uuid_service->generate())->save();
+  }
+
+  // Install new config: 'Errand service' and 'Service channel' views.
+  // Optional configurations are only installed if they are not already present.
+  \Drupal::service('config.installer')->installOptionalConfig($optional_config_source);
+  // Add Finnish translation for 'Errand service' and 'Service channel' views.
+  $views = ['views.view.tpr_errand_service_list', 'views.view.tpr_service_channel_list'];
+  foreach ($views as $view) {
+    $config_storage->createCollection('language.fi')->write($view, $language_config_source->read($view));
+  }
+}

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -442,7 +442,7 @@ function helfi_tpr_update_8025() : void {
   $language_config_path = drupal_get_path('module', 'helfi_tpr') . '/config/language/fi';
   $language_config_source = new FileStorage($language_config_path);
 
-  // Add new config: publish and unpublish actions for 'Errand service' and 'Service channel'.
+  // Add new configs for entity publish and unpublish actions.
   $actions = [
     'system.action.tpr_errand_service_publish_action',
     'system.action.tpr_errand_service_unpublish_action',
@@ -450,12 +450,13 @@ function helfi_tpr_update_8025() : void {
     'system.action.tpr_service_channel_unpublish_action',
   ];
   foreach ($actions as $action) {
-    $config_storage->write($action, $config_source->read($action));
-    $config_factory->getEditable($action)->set('uuid', $uuid_service->generate())->save();
+    if (empty($config_factory->loadMultiple([$action]))) {
+      $config_storage->write($action, $config_source->read($action));
+      $config_factory->getEditable($action)->set('uuid', $uuid_service->generate())->save();
+    }
   }
 
-  // Install new config: 'Errand service' and 'Service channel' views.
-  // Optional configurations are only installed if they are not already present.
+  // Install new configs for 'Errand service' and 'Service channel' views.
   \Drupal::service('config.installer')->installOptionalConfig($optional_config_source);
   // Add Finnish translation for 'Errand service' and 'Service channel' views.
   $views = ['views.view.tpr_errand_service_list', 'views.view.tpr_service_channel_list'];

--- a/tests/src/Functional/ErrandServiceListTest.php
+++ b/tests/src/Functional/ErrandServiceListTest.php
@@ -22,11 +22,4 @@ class ErrandServiceListTest extends ListTestBase {
     $this->adminListPath = '/admin/content/integrations/tpr-errand-service';
   }
 
-  /**
-   * Tests list view permissions.
-   */
-  public function testListPermissions() : void {
-    parent::testList();
-  }
-
 }

--- a/tests/src/Functional/ErrandServiceListTest.php
+++ b/tests/src/Functional/ErrandServiceListTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Functional;
+
+use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+
+/**
+ * Tests entity list functionality.
+ *
+ * @group helfi_tpr
+ */
+class ErrandServiceListTest extends MigrationTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'views',
+    'helfi_tpr',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests collection route (views).
+   */
+  public function testList() : void {
+    // Make sure anonymous user can't see the entity list.
+    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user without permissions can't see the entity list.
+    $account = $this->createUser();
+    $this->drupalLogin($account);
+    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user with access remote entities overview permission
+    // can see the entity list.
+    $account = $this->createUser([
+      'access remote entities overview'
+    ]);
+    $this->drupalLogin($account);
+    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('No results found.');
+  }
+
+}

--- a/tests/src/Functional/ErrandServiceListTest.php
+++ b/tests/src/Functional/ErrandServiceListTest.php
@@ -4,56 +4,29 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tpr\Functional;
 
-use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
-use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
-
 /**
- * Tests entity list functionality.
+ * Tests Errand Service entity's list functionality.
  *
  * @group helfi_tpr
  */
-class ErrandServiceListTest extends MigrationTestBase {
-
-  use ApiTestTrait;
+class ErrandServiceListTest extends ListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected static $modules = [
-    'views',
-    'helfi_tpr',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  protected $defaultTheme = 'stark';
-
-  /**
-   * Tests collection route (views).
-   */
-  public function testList() : void {
-    $adminListUrl = '/admin/content/integrations/tpr-errand-service';
-
-    // Make sure anonymous user can't see the entity list.
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(403);
-
-    // Make sure logged in user without permissions can't see the entity list.
-    $account = $this->createUser();
-    $this->drupalLogin($account);
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(403);
-
-    // Make sure logged in user with `access remote entities overview`
-    // permission can see the entity list.
-    $account = $this->createUser([
+  public function setUp() : void {
+    parent::setUp();
+    $this->listPermissions = [
       'access remote entities overview',
-    ]);
-    $this->drupalLogin($account);
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('No results found.');
+    ];
+    $this->adminListPath = '/admin/content/integrations/tpr-errand-service';
+  }
+
+  /**
+   * Tests list view permissions.
+   */
+  public function testListPermissions() : void {
+    parent::testList();
   }
 
 }

--- a/tests/src/Functional/ErrandServiceListTest.php
+++ b/tests/src/Functional/ErrandServiceListTest.php
@@ -33,23 +33,25 @@ class ErrandServiceListTest extends MigrationTestBase {
    * Tests collection route (views).
    */
   public function testList() : void {
+    $adminListUrl = '/admin/content/integrations/tpr-errand-service';
+
     // Make sure anonymous user can't see the entity list.
-    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(403);
 
     // Make sure logged in user without permissions can't see the entity list.
     $account = $this->createUser();
     $this->drupalLogin($account);
-    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(403);
 
-    // Make sure logged in user with access remote entities overview permission
-    // can see the entity list.
+    // Make sure logged in user with `access remote entities overview`
+    // permission can see the entity list.
     $account = $this->createUser([
-      'access remote entities overview'
+      'access remote entities overview',
     ]);
     $this->drupalLogin($account);
-    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('No results found.');
   }

--- a/tests/src/Functional/ListTestBase.php
+++ b/tests/src/Functional/ListTestBase.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Functional;
+
+use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+
+/**
+ * Tests entity list functionality.
+ *
+ * @group helfi_tpr
+ */
+abstract class ListTestBase extends MigrationTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static array $modules = [
+    'views',
+    'helfi_tpr',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected string $defaultTheme = 'stark';
+
+  /**
+   * The path for the migrated content's list page.
+   *
+   * @var string
+   */
+  protected string $adminListPath;
+
+  /**
+   * The array of the permission names allowing to view the list page.
+   *
+   * @var array
+   */
+  protected array $listPermissions;
+
+  /**
+   * Tests list view permissions.
+   */
+  protected function testList() : void {
+    // Make sure anonymous user can't see the entity list.
+    $this->drupalGet($this->adminListPath);
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user without permissions can't see the entity list.
+    $account = $this->createUser();
+    $this->drupalLogin($account);
+    $this->drupalGet($this->adminListPath);
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user with `access remote entities overview`
+    // permission can see the entity list.
+    $account = $this->createUser($this->listPermissions);
+    $this->drupalLogin($account);
+    $this->drupalGet($this->adminListPath);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('No results found.');
+  }
+
+}

--- a/tests/src/Functional/ListTestBase.php
+++ b/tests/src/Functional/ListTestBase.php
@@ -46,7 +46,7 @@ abstract class ListTestBase extends MigrationTestBase {
   /**
    * Tests list view permissions.
    */
-  protected function testList() : void {
+  public function testList() : void {
     // Make sure anonymous user can't see the entity list.
     $this->drupalGet($this->adminListPath);
     $this->assertSession()->statusCodeEquals(403);

--- a/tests/src/Functional/ListTestBase.php
+++ b/tests/src/Functional/ListTestBase.php
@@ -19,7 +19,7 @@ abstract class ListTestBase extends MigrationTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static array $modules = [
+  protected static $modules = [
     'views',
     'helfi_tpr',
   ];
@@ -27,7 +27,7 @@ abstract class ListTestBase extends MigrationTestBase {
   /**
    * {@inheritdoc}
    */
-  protected string $defaultTheme = 'stark';
+  protected $defaultTheme = 'stark';
 
   /**
    * The path for the migrated content's list page.

--- a/tests/src/Functional/ServiceChannelListTest.php
+++ b/tests/src/Functional/ServiceChannelListTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Functional;
+
+use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+
+/**
+ * Tests entity list functionality.
+ *
+ * @group helfi_tpr
+ */
+class ServiceChannelListTest extends MigrationTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'views',
+    'helfi_tpr',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests collection route (views).
+   */
+  public function testList() : void {
+    // Make sure anonymous user can't see the entity list.
+    $this->drupalGet('/admin/content/integrations/tpr-service-channel');
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user without permissions can't see the entity list.
+    $account = $this->createUser();
+    $this->drupalLogin($account);
+    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Make sure logged in user with access remote entities overview permission
+    // can see the entity list.
+    $account = $this->createUser([
+      'access remote entities overview'
+    ]);
+    $this->drupalLogin($account);
+    $this->drupalGet('/admin/content/integrations/tpr-service-channel');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('No results found.');
+  }
+
+}

--- a/tests/src/Functional/ServiceChannelListTest.php
+++ b/tests/src/Functional/ServiceChannelListTest.php
@@ -22,11 +22,4 @@ class ServiceChannelListTest extends ListTestBase {
     $this->adminListPath = '/admin/content/integrations/tpr-service-channel';
   }
 
-  /**
-   * Tests list view permissions.
-   */
-  public function testListPermissions() : void {
-    parent::testList();
-  }
-
 }

--- a/tests/src/Functional/ServiceChannelListTest.php
+++ b/tests/src/Functional/ServiceChannelListTest.php
@@ -4,56 +4,29 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tpr\Functional;
 
-use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
-use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
-
 /**
- * Tests entity list functionality.
+ * Tests Service Channel entity's list functionality.
  *
  * @group helfi_tpr
  */
-class ServiceChannelListTest extends MigrationTestBase {
-
-  use ApiTestTrait;
+class ServiceChannelListTest extends ListTestBase {
 
   /**
    * {@inheritdoc}
    */
-  protected static $modules = [
-    'views',
-    'helfi_tpr',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  protected $defaultTheme = 'stark';
-
-  /**
-   * Tests collection route (views).
-   */
-  public function testList() : void {
-    $adminListUrl = '/admin/content/integrations/tpr-service-channel';
-
-    // Make sure anonymous user can't see the entity list.
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(403);
-
-    // Make sure logged in user without permissions can't see the entity list.
-    $account = $this->createUser();
-    $this->drupalLogin($account);
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(403);
-
-    // Make sure logged in user with `access remote entities overview`
-    // permission can see the entity list.
-    $account = $this->createUser([
+  public function setUp() : void {
+    parent::setUp();
+    $this->listPermissions = [
       'access remote entities overview',
-    ]);
-    $this->drupalLogin($account);
-    $this->drupalGet($adminListUrl);
-    $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('No results found.');
+    ];
+    $this->adminListPath = '/admin/content/integrations/tpr-service-channel';
+  }
+
+  /**
+   * Tests list view permissions.
+   */
+  public function testListPermissions() : void {
+    parent::testList();
   }
 
 }

--- a/tests/src/Functional/ServiceChannelListTest.php
+++ b/tests/src/Functional/ServiceChannelListTest.php
@@ -33,23 +33,25 @@ class ServiceChannelListTest extends MigrationTestBase {
    * Tests collection route (views).
    */
   public function testList() : void {
+    $adminListUrl = '/admin/content/integrations/tpr-service-channel';
+
     // Make sure anonymous user can't see the entity list.
-    $this->drupalGet('/admin/content/integrations/tpr-service-channel');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(403);
 
     // Make sure logged in user without permissions can't see the entity list.
     $account = $this->createUser();
     $this->drupalLogin($account);
-    $this->drupalGet('/admin/content/integrations/tpr-errand-service');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(403);
 
-    // Make sure logged in user with access remote entities overview permission
-    // can see the entity list.
+    // Make sure logged in user with `access remote entities overview`
+    // permission can see the entity list.
     $account = $this->createUser([
-      'access remote entities overview'
+      'access remote entities overview',
     ]);
     $this->drupalLogin($account);
-    $this->drupalGet('/admin/content/integrations/tpr-service-channel');
+    $this->drupalGet($adminListUrl);
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('No results found.');
   }

--- a/tests/src/Functional/UnitListTest.php
+++ b/tests/src/Functional/UnitListTest.php
@@ -5,31 +5,17 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_tpr\Functional;
 
 use Drupal\helfi_tpr\Entity\Unit;
-use Drupal\Tests\helfi_api_base\Functional\MigrationTestBase;
 use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * Tests entity list functionality.
+ * Tests Unit entity's list functionality.
  *
  * @group helfi_tpr
  */
-class UnitListTest extends MigrationTestBase {
+class UnitListTest extends ListTestBase {
 
   use ApiTestTrait;
-
-  /**
-   * {@inheritdoc}
-   */
-  protected static $modules = [
-    'views',
-    'helfi_tpr',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
-  protected $defaultTheme = 'stark';
 
   /**
    * Migrates the tpr unit entities.
@@ -52,7 +38,7 @@ class UnitListTest extends MigrationTestBase {
   }
 
   /**
-   * Asserts that the item is published or unpublishedt.
+   * Asserts that the item is published or unpublished.
    *
    * @param int $nthChild
    *   The nth child.
@@ -68,23 +54,22 @@ class UnitListTest extends MigrationTestBase {
   }
 
   /**
-   * Tests collection route (views).
+   * {@inheritdoc}
    */
-  public function testList() : void {
-    // Make sure anonymous user can't see the entity list.
-    $this->drupalGet('/admin/content/integrations/tpr-unit');
-    $this->assertSession()->statusCodeEquals(403);
-
-    // Make sure logged in user with access remote entities overview permission
-    // can see the entity list.
-    $account = $this->createUser([
+  public function setUp() : void {
+    parent::setUp();
+    $this->listPermissions = [
       'access remote entities overview',
       'administer tpr_unit',
-    ]);
-    $this->drupalLogin($account);
-    $this->drupalGet('/admin/content/integrations/tpr-unit');
-    $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('No results found.');
+    ];
+    $this->adminListPath = '/admin/content/integrations/tpr-unit';
+  }
+
+  /**
+   * Tests list view permissions, and viewing, updating, and publishing units.
+   */
+  public function testList() : void {
+    parent::testList();
 
     // Migrate entities and make sure we can see all entities from fixture.
     $this->runMigrate();


### PR DESCRIPTION
Testing:
* If you don't already have a site for testing, create one:
  * `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
  * cd hel-platform
  * make new
* Update the module to include changes: `composer require drupal/helfi_tpr:dev-UHF-1772-missing-integration-overviews`
* Run `drush updb`
* Make sure you have imported some "Errand service" and "Service channel" content. If not, run:
  * `drush migrate:import tpr_errand_service`
  * `drush migrate:import tpr_service_channel`
* As an anonymous user, go to the pages `/admin/content/integrations/tpr-errand-service` and `admin/content/integrations/tpr-service-channel`. You should **not** see any content.
* As an admin user (for testing purposes, use a user whose UID is **not** 1), go to the same pages and you **should see** the list of the migrated content.
  * Test that it's possible to publish multiple items using the bulk update functionality.

Also check the site specific PRs:
* [drupal-helfi/pull/168](https://github.com/City-of-Helsinki/drupal-helfi/pull/168)
* [drupal-helfi-sote/pull/55](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/55)
* [drupal-helfi-kymp/pull/51](https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/51)