### PR TITLE
UHF-1740 Prevent deletions

### DIFF
--- a/helfi_tpr.links.task.yml
+++ b/helfi_tpr.links.task.yml
@@ -35,12 +35,6 @@ entity.tpr_errand_service.edit_form:
   route_name: entity.tpr_errand_service.edit_form
   base_route: entity.tpr_errand_service.canonical
 
-entity.tpr_errand_service.delete_form:
-  title: Delete
-  route_name: entity.tpr_errand_service.delete_form
-  base_route: entity.tpr_errand_service.canonical
-  weight: 10
-
 tpr_errand_service.content_list:
   title: TPR - Errand Service
   route_name: entity.tpr_errand_service.collection
@@ -61,12 +55,6 @@ entity.tpr_service_channel.edit_form:
   title: Edit
   route_name: entity.tpr_service_channel.edit_form
   base_route: entity.tpr_service_channel.canonical
-
-entity.tpr_service_channel.delete_form:
-  title: Delete
-  route_name: entity.tpr_service_channel.delete_form
-  base_route: entity.tpr_service_channel.canonical
-  weight: 10
 
 tpr_service_channel.content_list:
   title: TPR - Service channel

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -53,7 +53,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   links = {
  *     "canonical" = "/tpr-service_channel/{tpr_service_channel}",
  *     "edit-form" = "/admin/content/integrations/tpr-service-channel/{tpr_service_channel}/edit",
- *     "delete-form" = "/admin/content/integrations/tpr-service-channel/{tpr_service_channel}/delete",
  *     "collection" = "/admin/content/integrations/tpr-service-channel"
  *   },
  *   field_ui_base_route = "tpr_service_channel.settings"

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -24,7 +24,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",
- *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
  *     },
  *     "route_provider" = {
  *       "html" = "Drupal\helfi_api_base\Entity\Routing\EntityRouteProvider",

--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -22,7 +22,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",
- *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm"
  *     },
  *     "route_provider" = {
  *       "html" = "Drupal\helfi_api_base\Entity\Routing\EntityRouteProvider",

--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -51,7 +51,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   links = {
  *     "canonical" = "/tpr-errand-service/{tpr_errand_service}",
  *     "edit-form" = "/admin/content/integrations/tpr-errand-service/{tpr_errand_service}/edit",
- *     "delete-form" = "/admin/content/integrations/tpr-errand-service/{tpr_errand_service}/delete",
  *     "collection" = "/admin/content/integrations/tpr-errand-service"
  *   },
  *   field_ui_base_route = "tpr_errand_service.settings"

--- a/src/Entity/TprEntityBase.php
+++ b/src/Entity/TprEntityBase.php
@@ -174,4 +174,18 @@ abstract class TprEntityBase extends RemoteEntityBase implements RevisionableInt
     return $fields;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function delete() {
+    // Disable deleting entities to prevent accidental automatic deletions.
+    // Also, deleting using the UI is not currently supported.
+    // @todo Implement a safe way to delete entities.
+    \Drupal::logger('helfi_tpr')->notice('Prevented deleting entity @type with ID @id. Deleting TPR entities is disabled.',
+      array(
+        '@id' => $this->id(),
+        '@type' => $this->getEntityTypeId(),
+      ));
+  }
+
 }

--- a/src/Entity/TprEntityBase.php
+++ b/src/Entity/TprEntityBase.php
@@ -182,10 +182,10 @@ abstract class TprEntityBase extends RemoteEntityBase implements RevisionableInt
     // Also, deleting using the UI is not currently supported.
     // @todo Implement a safe way to delete entities.
     \Drupal::logger('helfi_tpr')->notice('Prevented deleting entity @type with ID @id. Deleting TPR entities is disabled.',
-      array(
+      [
         '@id' => $this->id(),
         '@type' => $this->getEntityTypeId(),
-      ));
+      ]);
   }
 
 }

--- a/tests/src/Kernel/ChannelEntityTest.php
+++ b/tests/src/Kernel/ChannelEntityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\helfi_tpr\Entity\Channel;
+
+/**
+ * Tests TPR Service Channel entities.
+ *
+ * @group helfi_tpr
+ */
+class ChannelEntityTest extends MigrationTestBase {
+
+  /**
+   * Gets the TPR Service Channel entity.
+   *
+   * @param int $id
+   *   The id.
+   *
+   * @return \Drupal\helfi_tpr\Entity\Channel
+   *   The entity.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function getEntity(int $id) : Channel {
+    $entity = Channel::create([
+      'id' => $id,
+      'name' => 'TPR Service Channel ' . $id,
+    ]);
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Tests entity deletion.
+   */
+  public function testEntityDeletion() : void {
+    $entity = $this->getEntity(1);
+
+    // Test that the entity is not deleted.
+    // See Drupal\helfi_tpr\Entity\TprEntityBase::delete() for more
+    // information.
+    $entity->delete();
+    $this->assertNotEquals(NULL, Channel::load(1));
+  }
+
+}

--- a/tests/src/Kernel/ErrandServiceEntityTest.php
+++ b/tests/src/Kernel/ErrandServiceEntityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\helfi_tpr\Entity\ErrandService;
+
+/**
+ * Tests TPR Errand Service entities.
+ *
+ * @group helfi_tpr
+ */
+class ErrandServiceEntityTest extends MigrationTestBase {
+
+  /**
+   * Gets the TPR Errand Service entity.
+   *
+   * @param int $id
+   *   The id.
+   *
+   * @return \Drupal\helfi_tpr\Entity\ErrandService
+   *   The entity.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function getEntity(int $id) : ErrandService {
+    $entity = ErrandService::create([
+      'id' => $id,
+      'name' => 'TPR Errand Service ' . $id,
+    ]);
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Tests entity deletion.
+   */
+  public function testEntityDeletion() : void {
+    $entity = $this->getEntity(1);
+
+    // Test that the entity is not deleted.
+    // See Drupal\helfi_tpr\Entity\TprEntityBase::delete() for more
+    // information.
+    $entity->delete();
+    $this->assertNotEquals(NULL, ErrandService::load(1));
+  }
+
+}

--- a/tests/src/Kernel/ServiceEntityTest.php
+++ b/tests/src/Kernel/ServiceEntityTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\helfi_tpr\Entity\Service;
+
+/**
+ * Tests TPR Service entities.
+ *
+ * @group helfi_tpr
+ */
+class ServiceEntityTest extends MigrationTestBase {
+
+  /**
+   * Gets the TPR Service entity.
+   *
+   * @param int $id
+   *   The id.
+   *
+   * @return \Drupal\helfi_tpr\Entity\Service
+   *   The entity.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function getEntity(int $id) : Service {
+    $entity = Service::create([
+      'id' => $id,
+      'name' => 'TPR Service ' . $id,
+    ]);
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Tests entity deletion.
+   */
+  public function testEntityDeletion() : void {
+    $entity = $this->getEntity(1);
+
+    // Test that the entity is not deleted.
+    // See Drupal\helfi_tpr\Entity\TprEntityBase::delete() for more
+    // information.
+    $entity->delete();
+    $this->assertNotEquals(NULL, Service::load(1));
+  }
+
+}

--- a/tests/src/Kernel/UnitEntityTest.php
+++ b/tests/src/Kernel/UnitEntityTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tpr\Kernel;
 
-use Drupal\Core\Entity\EntityStorageException;
 use Drupal\helfi_tpr\Entity\Unit;
 
 /**
@@ -20,10 +19,10 @@ class UnitEntityTest extends MigrationTestBase {
    * @param int $id
    *   The id.
    *
-   * @return Unit
+   * @return \Drupal\helfi_tpr\Entity\Unit
    *   The entity.
    *
-   * @throws EntityStorageException
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   protected function getEntity(int $id) : Unit {
     $entity = Unit::create([

--- a/tests/src/Kernel/UnitEntityTest.php
+++ b/tests/src/Kernel/UnitEntityTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\helfi_tpr\Entity\Unit;
+
+/**
+ * Tests TPR Unit entities.
+ *
+ * @group helfi_tpr
+ */
+class UnitEntityTest extends MigrationTestBase {
+
+  /**
+   * Gets the TPR Unit entity.
+   *
+   * @param int $id
+   *   The id.
+   *
+   * @return Unit
+   *   The entity.
+   *
+   * @throws EntityStorageException
+   */
+  protected function getEntity(int $id) : Unit {
+    $entity = Unit::create([
+      'id' => $id,
+      'name' => 'TPR Unit ' . $id,
+    ]);
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Tests entity deletion.
+   */
+  public function testEntityDeletion() : void {
+    $entity = $this->getEntity(1);
+
+    // Test that the entity is not deleted.
+    // See Drupal\helfi_tpr\Entity\TprEntityBase::delete() for more
+    // information.
+    $entity->delete();
+    $this->assertNotEquals(NULL, Unit::load(1));
+  }
+
+}


### PR DESCRIPTION
How to test:
* If you don't already have a site for testing, create one:
  * `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
  * `cd hel-platform`
  * `make new`
  * Enable the module: `drush en -y helfi_tpr`
* Update the module to include changes: `composer require drupal/helfi_tpr:dev-UHF-1740-prevent-deletions`
*  Clear caches: `drush cr`
* Check that deleting TPR entities (especially Errand services and Service channels) is no longer possible using the admin UI: there are no "Delete" links.
* One way to check that TPR entities are not deleted during the import is to temporarily change the `MAX_SYNC_ATTEMPTS` constant at `TprEntityBase` to 1. Then running the import with a not yet supported limit option, e.g. `drush migrate:import --limit=1 tpr_service`, which would delete all Service entities before this change, will now output _"Prevented deleting entity tpr_service with ID ..."_ and the entities are not deleted.