### PR TITLE
UHF-2014 Missing email and link

### DIFF
--- a/migrations/tpr_unit.yml
+++ b/migrations/tpr_unit.yml
@@ -73,6 +73,7 @@ process:
     source: phone
     delimiter: ','
     strict: false
+  email: email
   changed:
     -
       plugin: format_date

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -212,7 +212,11 @@ class Unit extends TprEntityBase {
       ->setTranslatable(FALSE);
     $fields['accessibility_email'] = static::createStringField('Accessibility email')
       ->setTranslatable(FALSE);
-    $fields['www'] = static::createLinkField('Website link');
+    $fields['www'] = static::createLinkField('Website link')
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'link',
+      ]);
     $fields['accessibility_www'] = static::createLinkField('Accessibility website link')
       ->setTranslatable(FALSE);
     $fields['description'] = BaseFieldDefinition::create('text_with_summary')

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -121,7 +121,7 @@
             {% if content.www|render %}
               <div class="unit__contact-row unit__contact-row--website-link">
                 <label class="unit__contact-row__label">
-                  {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'display'} %}
+                  {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'globe'} %}
                   {{ 'Elsewhere on the web'|t }}:
                 </label>
                 {{ content.www|render }}

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -122,7 +122,7 @@
               <div class="unit__contact-row unit__contact-row--website-link">
                 <label class="unit__contact-row__label">
                   {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'display'} %}
-                  {{ ' Elsewhere on the web'|t }}:
+                  {{ 'Elsewhere on the web'|t }}:
                 </label>
                 {{ content.www|render }}
               </div>

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -66,7 +66,8 @@
           content.email|render or
           content.phone|render or
           content.address_postal|render or
-          content.opening_hours|render
+          content.opening_hours|render or
+          content.www|render
         %}
           <div class="unit__contact">
             <h3 class="unit__contact__title">
@@ -115,6 +116,15 @@
                   {{ 'Postal address'|t }}:
                 </label>
                 {{ content.address_postal }}
+              </div>
+            {% endif %}
+            {% if content.www|render %}
+              <div class="unit__contact-row unit__contact-row--website-link">
+                <label class="unit__contact-row__label">
+                  {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'display'} %}
+                  {{ ' Elsewhere on the web'|t }}:
+                </label>
+                {{ content.www|render }}
               </div>
             {% endif %}
           </div>

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -87,7 +87,7 @@
                   {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'envelope'} %}
                   {{ 'E-mail'|t }}:
                 </label>
-                <a href="mailto:{{ content.email }}">{{ content.email }}</a>
+                <a href="mailto:{{ content.email|render|striptags|trim|lower }}">{{ content.email }}</a>
               </div>
             {% endif %}
             {% if content.phone|render %}


### PR DESCRIPTION
Adds missing email and link ("Elsewhere on the web") to TPR Unit pages.

How to test
* Choose which site to test: drupal-helfi-sote, drupal-helfi-kymp, drupal-helfi-strategia or drupal-helfi.
* Checkout branch named `UHF-2014-missing-email-links` from the site repository.
* Get changes to TPR module: `composer require drupal/helfi_tpr:dev-UHF-2014_missing_email`
* Get changes to platform config `composer require drupal/helfi_platform_config:dev-UHF-2014-missing-email-links`
* Using `make shell`:
  * Import configs: `drush cim`
  * Import locales: `drush locale-import fi /app/public/modules/contrib/helfi_platform_config/translations/fi/strings.po`
  * Clear caches: `drush cr`
  * Migrate some TPR Units: `MIGRATE_LIMIT=50 drush migrate:import tpr_unit`
* From the newly migrated Units, find a one which has an email and a website link. Check that viewing the page shows the email and "Elsewhere on the web" link. On the Finnish unit pages, the link label is translated to "Muualla webissä".

Please also review these related PRs:
* [drupal-helfi-platform-config/pull/139](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/139)
* [drupal-helfi-sote/pull/66](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/66)
* [drupal-helfi-kymp/pull/63](https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/63)
* [drupal-helfi-strategia/pull/18](https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/18)
* [drupal-helfi/pull/178](https://github.com/City-of-Helsinki/drupal-helfi/pull/178)