### PR TITLE
UHF-1717: TPR unit provided languages

### DIFF
--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -466,7 +466,7 @@ function helfi_tpr_update_8025() : void {
 }
 
 /**
- * Adds 'service_languages' field to 'tpr_unit'
+ * Adds 'provided_languages' field to 'tpr_unit' entity
  */
 function helfi_tpr_update_8026() : void {
   $fields['provided_languages'] = BaseFieldDefinition::create('string')

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -473,6 +473,9 @@ function helfi_tpr_update_8026() : void {
     ->setLabel(new TranslatableMarkup('Provided languages'))
     ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
     ->setTranslatable(FALSE)
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
     ->setDisplayConfigurable('view', TRUE)
     ->setDisplayConfigurable('form', TRUE);
 

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -464,3 +464,20 @@ function helfi_tpr_update_8025() : void {
     $config_storage->createCollection('language.fi')->write($view, $language_config_source->read($view));
   }
 }
+
+/**
+ * Adds 'service_languages' field to 'tpr_unit'
+ */
+function helfi_tpr_update_8026() : void {
+  $fields['provided_languages'] = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('Provided languages'))
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setTranslatable(FALSE)
+    ->setDisplayConfigurable('view', TRUE)
+    ->setDisplayConfigurable('form', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
+  }
+}

--- a/migrations/tpr_unit.yml
+++ b/migrations/tpr_unit.yml
@@ -20,7 +20,7 @@ source:
     - desc
     - short_desc
   track_changes: true
-  url: 'https://www.hel.fi/palvelukarttaws/rest/v4/unit/'
+  url: 'https://www.hel.fi/palvelukarttaws/rest/v4/unit/?newfeatures=yes'
   accessibility_sentences_url: 'https://www.hel.fi/palvelukarttaws/rest/v4/accessibility_sentence/'
   connections_url: 'https://www.hel.fi/palvelukarttaws/rest/v4/connection/'
 process:
@@ -74,6 +74,7 @@ process:
     delimiter: ','
     strict: false
   email: email
+  provided_languages: provided_languages
   changed:
     -
       plugin: format_date

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -300,6 +300,9 @@ class Unit extends TprEntityBase {
       ->setLabel(new TranslatableMarkup('Provided languages'))
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setTranslatable(FALSE)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -296,6 +296,12 @@ class Unit extends TprEntityBase {
       ->setTranslatable(TRUE)
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE);
+    $fields['provided_languages'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Provided languages'))
+      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+      ->setTranslatable(FALSE)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE);
 
     return $fields;
   }

--- a/src/Fixture/Unit.php
+++ b/src/Fixture/Unit.php
@@ -118,6 +118,11 @@ final class Unit extends FixtureBase {
             'www_fi' => 'https://link.fi',
           ],
         ],
+        'provided_languages' => [
+          'fi',
+          'sv',
+          'en',
+        ],
       ],
     ];
   }

--- a/tests/src/Kernel/UnitMigrationTest.php
+++ b/tests/src/Kernel/UnitMigrationTest.php
@@ -40,6 +40,14 @@ class UnitMigrationTest extends MigrationTestBase {
 
       $this->assertEquals(2, $translation->get('accessibility_sentences')->count());
 
+      $provided_languages = [];
+
+      foreach ($translation->get('provided_languages')->getValue() as $value) {
+        $provided_languages[] = $value['value'];
+      }
+
+      $this->assertEquals(['fi', 'sv', 'en'], $provided_languages);
+
       for ($i = 0; $i < 2; $i++) {
         $delta = $i + 1;
         $this->assertEquals("Group $langcode $delta", $translation->get('accessibility_sentences')->get($i)->group);


### PR DESCRIPTION
How to test (in a working environment):

- checkout this branch: `composer require drupal/helfi_tpr:dev-UHF-1717_palvelukielet`
- run `drush updb`
- import some TPR units and see the new imported data from the database (`tpr_unit__provided_languages` table)
  - optionally, you can set the `Provided languages` field visible temporarily in the UI