### PR TITLE
Removed elsewhere on the web element

### DIFF
--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -66,8 +66,7 @@
           content.email|render or
           content.phone|render or
           content.address_postal|render or
-          content.opening_hours|render or
-          content.www|render
+          content.opening_hours|render
         %}
           <div class="unit__contact">
             <h3 class="unit__contact__title">

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -118,15 +118,6 @@
                 {{ content.address_postal }}
               </div>
             {% endif %}
-            {% if content.www|render %}
-              <div class="unit__contact-row unit__contact-row--website-link">
-                <label class="unit__contact-row__label">
-                  {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'globe'} %}
-                  {{ 'Elsewhere on the web'|t }}:
-                </label>
-                {{ content.www|render }}
-              </div>
-            {% endif %}
           </div>
         {% endif %}
 


### PR DESCRIPTION
Removes the "Elsewhere on the web" element from TPR Unit page.

Test:
1. Select one of the websites which uses helfi_tpr module (or  run "drush en -y helfi_tpr" inside container)
2. Import some TPR unit entities "MIGRATE_LIMIT=20 drush mim tpr_unit"
 - At this point you might want to check which units contain the "elsewhere on web" element for future reference.
3. Get changes to TPR module: "composer require drupal/helfi_tpr:dev-UHF-2516_remove_elsewhere_element"
4. Run "drush cr" inside container (should be enough with this small feature)
5. Go check the TPR unit page which used to have "elsewhere on web" element. The element should be gone.

