### PR TITLE
UHF-2506: Set TPR Service's errand_services field translatable

### DIFF
--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -210,6 +210,7 @@ class Service extends TprEntityBase {
         'type' => 'readonly_field_widget',
       ])
       ->setRevisionable(FALSE)
+      ->setTranslatable(TRUE)
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);


### PR DESCRIPTION
Sets TPR Service's errand_services field translatable to fix the disappearing errand service references.

How to test:
* If you don't already have a site for testing, create one:
  * `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
  * `cd hel-platform`
  * `make new`
  * Enable TPR module and configs: (using `make shell`):`drush en -y helfi_tpr helfi_tpr_config`
* First, import TPR content before applying the change (using `make shell`):
  * `drush migrate:import tpr_errand_service`
  * `drush migrate:import tpr_service`
  * `drush migrate:import tpr_service_channel`
* Use the TPR service with ID 4093 (`/fi/tpr-service/4093`) as an example, since currently its Finnish version contains Errand services and others do not.
  * At this point (first migration), the Finnish translation (`/fi/tpr-service/4093`) probably contains the Errand service as it should.
* Re-run the `tpr_service` migration:
  * `drush migrate:import tpr_service`
* At this point, the errand service will probably disappear (the bug).
* Update the module to include the change: `composer require drupal/helfi_tpr:dev-UHF-2506-fix-service-errand-service`
* Clear caches: `drush cr`
* Now, re-run the `tpr_service` migration again:
  * `drush migrate:import tpr_service`
* At this point, the service example's Finnish page (`/fi/tpr-service/4093`) should contain the Errand service, and other language versions (`/sv/tpr-service/4093` and `/en/tpr-service/4093`) do not.
* Also for another example, check that TPR service with ID 2587 contains errand service(s) with all translations (`/fi/tpr-service/2587`, `/sv/tpr-service/2587` and `/en/tpr-service/2587`) , as its errand service is currently translated.