### PR TITLE
UHF-833: Remove obsolete config rewrite

### DIFF
--- a/config/rewrite/pathauto.settings.yml
+++ b/config/rewrite/pathauto.settings.yml
@@ -1,4 +1,0 @@
-enabled_entity_types:
-  - tpr_service
-  - tpr_unit
-  - user


### PR DESCRIPTION
The config rewrite prevents using helfi_tpr module as dependency.

The removed config rewrite is implemented at helfi_tpr_config module: helfi_tpr_config_update_9002.