### PR TITLE
UHF-405: provided_languages variable for the template

### DIFF
--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -108,7 +108,7 @@ function template_preprocess_tpr_unit(array &$variables) {
     $variables['content']['description_summary'] = $variables['elements']['#tpr_unit']->get('description')->summary;
   }
   // Get provided languages for the template.
-  $provided_languages = $variables['elements']['#tpr_unit']->get('provided_languages')->getValue();
+  $provided_languages = $variables['entity']->get('provided_languages')->getValue();
 
   foreach ($provided_languages as $provided_language) {
     $variables['provided_languages'][] = $provided_language['value'];

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -106,12 +106,13 @@ function template_preprocess_tpr_unit(array &$variables) {
   if (isset($variables['elements']['#tpr_unit'])) {
     $variables['entity'] = $variables['elements']['#tpr_unit'];
     $variables['content']['description_summary'] = $variables['elements']['#tpr_unit']->get('description')->summary;
-  }
-  // Get provided languages for the template.
-  $provided_languages = $variables['entity']->get('provided_languages')->getValue();
 
-  foreach ($provided_languages as $provided_language) {
-    $variables['provided_languages'][] = $provided_language['value'];
+    // Get provided languages for the template.
+    $provided_languages = $variables['entity']->get('provided_languages')->getValue();
+
+    foreach ($provided_languages as $provided_language) {
+      $variables['provided_languages'][] = $provided_language['value'];
+    }
   }
 }
 

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -107,6 +107,12 @@ function template_preprocess_tpr_unit(array &$variables) {
     $variables['entity'] = $variables['elements']['#tpr_unit'];
     $variables['content']['description_summary'] = $variables['elements']['#tpr_unit']->get('description')->summary;
   }
+  // Get provided languages for the template.
+  $provided_languages = $variables['elements']['#tpr_unit']->get('provided_languages')->getValue();
+
+  foreach ($provided_languages as $provided_language) {
+    $variables['provided_languages'][] = $provided_language['value'];
+  }
 }
 
 /**


### PR DESCRIPTION
How to set up:
- Run SOTE instance
- Check out this branch of the module: `composer require drupal/helfi_tpr:dev-UHF-405_provided_languages_variable`
- Clear caches: `make drush-cr`
- There should now be a `provided_languages` array variable available in the TPR unit template