### PR TITLE
UHF-405: Add supports Swedish data to template

### DIFF
--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -14,6 +14,14 @@
   ]
 %}
 
+{% set supports_swedish %}
+  {% if 'sv' in provided_languages %}
+    <div class="unit__supports_language_sv">
+      {{ 'Service in Swedish'|t({}, {'context': 'TPR unit also offers service in Swedish'}) }}
+    </div>
+  {% endif %}
+{% endset %}
+
 {% if view_mode == 'full' %}
 
   <article{{ attributes.addClass(classes) }}>
@@ -28,6 +36,7 @@
           </div>
         {% endif %}
         <span class="unit__divider"></span>
+        {{ supports_swedish }}
         {% if content.picture_url_override|render %}
           <div class="unit__image">
             {{ content.picture_url_override }}
@@ -170,6 +179,7 @@
           </span>
         </div>
       {% endif %}
+      {{ supports_swedish }}
     </div>
     <a href="{{ url('entity.tpr_unit.canonical', { 'tpr_unit': entity.id() }) }}" class="unit__link">
       <span class="is-hidden">{% trans with {'context': 'Unit teaser link'} %}Go to{% endtrans %} {{ content.name }}</span>
@@ -224,6 +234,7 @@
             </div>
           {% endif %}
         </div>
+        {{ supports_swedish }}
       </div>
       <a href="{{ url('entity.tpr_unit.canonical', { 'tpr_unit': entity.id() }) }}" class="unit__link">
         <span class="is-hidden">{% trans with {'context': 'Unit teaser link'} %}Go to{% endtrans %} {{ content.name }}</span>


### PR DESCRIPTION
# Show in units if they have "Service in Swedish"

[UHF-405](https://helsinkisolutionoffice.atlassian.net/browse/UHF-405)

## What was done

* Added the "Service in Swedish" tag to unit, teaser, teaser with image (but not to teaser wide, because Elina asked not to)

## How to test

- Run SOTE instance
- Check out this branch of the module: `composer require drupal/helfi_tpr:dev-UHF-405_unit_service_in_lang_sv`
- Clear caches: `make drush-cr`
- There should now be a Service in Swedish text on the unit page, teaser and teaser with image
- Check this together with the related [hdbt PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/153) to see the styling.

Related: [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/153)