### PR TITLE
UHF-2103: Redirect & confirmation message when editing TPR Unit or Service entities

### DIFF
--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -6,8 +6,6 @@
  */
 
 use Drupal\Core\Render\Element;
-use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_theme().

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -173,30 +173,3 @@ function template_preprocess_tpr_errand_service(array &$variables) {
     //$variables['content']['description_summary'] = $variables['elements']['#tpr_service_channel']->get('description')->summary;
   }
 }
-
-/**
- * Implements hook_form_alter().
- */
-function helfi_tpr_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Add a custom submit handler for TPR Unit and TPR Service entity edit forms.
-  if ($form_id == 'tpr_unit_form' || $form_id == 'tpr_service_form') {
-    $form['actions']['submit']['#submit'][] = 'helfi_tpr_form_submit';
-  }
-}
-
-/**
- * Custom submit handler for TPR Unit and TPR Service entity edit forms.
- */
-function helfi_tpr_form_submit(array $form, FormStateInterface $form_state) {
-  $form_object = $form_state->getFormObject();
-
-  if ($form_object instanceof \Drupal\Core\Entity\EntityFormInterface) {
-    $entity = $form_object->getEntity();
-
-    \Drupal::messenger()->addStatus(t('%title saved.', ['%title' => $entity->label()]));
-
-    $url = $entity->toUrl()->toString();
-    $redirect = new RedirectResponse($url);
-    $redirect->send();
-  }
-}

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -188,11 +188,15 @@ function helfi_tpr_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Custom submit handler for TPR Unit and TPR Service entity edit forms.
  */
 function helfi_tpr_form_submit(array $form, FormStateInterface $form_state) {
-  $entity = $form_state->getFormObject()->getEntity();
+  $form_object = $form_state->getFormObject();
 
-  \Drupal::messenger()->addStatus(t('%title saved.', ['%title' => $entity->label()]));
+  if ($form_object instanceof \Drupal\Core\Entity\EntityFormInterface) {
+    $entity = $form_object->getEntity();
 
-  $url = $entity->toUrl()->toString();
-  $redirect = new RedirectResponse($url);
-  $redirect->send();
+    \Drupal::messenger()->addStatus(t('%title saved.', ['%title' => $entity->label()]));
+
+    $url = $entity->toUrl()->toString();
+    $redirect = new RedirectResponse($url);
+    $redirect->send();
+  }
 }

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Render\Element;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_theme().
@@ -170,4 +172,27 @@ function template_preprocess_tpr_errand_service(array &$variables) {
     $variables['entity'] = $variables['elements']['#tpr_errand_service'];
     //$variables['content']['description_summary'] = $variables['elements']['#tpr_service_channel']->get('description')->summary;
   }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function helfi_tpr_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add a custom submit handler for TPR Unit and TPR Service entity edit forms.
+  if ($form_id == 'tpr_unit_form' || $form_id == 'tpr_service_form') {
+    $form['actions']['submit']['#submit'][] = 'helfi_tpr_form_submit';
+  }
+}
+
+/**
+ * Custom submit handler for TPR Unit and TPR Service entity edit forms.
+ */
+function helfi_tpr_form_submit(array $form, FormStateInterface $form_state) {
+  $entity = $form_state->getFormObject()->getEntity();
+
+  \Drupal::messenger()->addStatus(t('%title saved.', ['%title' => $entity->label()]));
+
+  $url = $entity->toUrl()->toString();
+  $redirect = new RedirectResponse($url);
+  $redirect->send();
 }

--- a/src/Entity/Form/ContentEntityForm.php
+++ b/src/Entity/Form/ContentEntityForm.php
@@ -122,4 +122,21 @@ class ContentEntityForm extends CoreContentEntityForm {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity_type = $this->entity->getEntityTypeId();
+
+    if ($entity_type == 'tpr_unit' || $entity_type == 'tpr_service') {
+      parent::save($form, $form_state);
+
+      $this->messenger()->addStatus(t('%title saved.', ['%title' => $this->entity->label()]));
+
+      $form_state->setRedirect('entity.' . $entity_type . '.canonical', [
+        $entity_type => $this->entity->id(),
+      ]);
+    }
+  }
+
 }

--- a/tests/src/Functional/ServiceMenuLinkTest.php
+++ b/tests/src/Functional/ServiceMenuLinkTest.php
@@ -61,6 +61,10 @@ class ServiceMenuLinkTest extends MigrationTestBase {
         'menu[title]' => "Menu link $language",
       ], 'Save');
 
+      $this->drupalGet(Url::fromRoute('entity.tpr_service.edit_form', ['tpr_service' => 1]), [
+        'query' => ['language' => $language],
+      ]);
+
       $this->assertSession()->checkboxChecked('menu[enabled]');
       $this->assertSession()->fieldValueEquals('menu[title]', "Menu link $language");
 

--- a/tests/src/Functional/ServiceTranslationTest.php
+++ b/tests/src/Functional/ServiceTranslationTest.php
@@ -42,6 +42,9 @@ class ServiceTranslationTest extends MigrationTestBase {
       $this->submitForm([
         'content_translation[status]' => $expected_status,
       ], 'Save');
+      $this->drupalGet(Url::fromRoute('entity.tpr_service.edit_form', ['tpr_service' => 1]), [
+        'query' => ['language' => 'fi'],
+      ]);
       $this->assertSession()->fieldValueEquals('content_translation[status]', $expected_status);
     }
 
@@ -59,6 +62,9 @@ class ServiceTranslationTest extends MigrationTestBase {
         $this->submitForm([
           'content_translation[status]' => $expected_status,
         ], 'Save');
+        $this->drupalGet(Url::fromRoute('entity.tpr_service.edit_form', ['tpr_service' => 1]), [
+          'query' => ['language' => $language],
+        ]);
         $this->assertSession()->fieldValueEquals('content_translation[status]', $expected_status);
       }
     }

--- a/tests/src/Functional/UnitMenuLinkTest.php
+++ b/tests/src/Functional/UnitMenuLinkTest.php
@@ -60,6 +60,10 @@ class UnitMenuLinkTest extends MigrationTestBase {
         'menu[title]' => "Menu link $language",
       ], 'Save');
 
+      $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 1]), [
+        'query' => ['language' => $language],
+      ]);
+
       $this->assertSession()->checkboxChecked('menu[enabled]');
       $this->assertSession()->fieldValueEquals('menu[title]', "Menu link $language");
 

--- a/tests/src/Functional/UnitTranslationTest.php
+++ b/tests/src/Functional/UnitTranslationTest.php
@@ -42,6 +42,9 @@ class UnitTranslationTest extends MigrationTestBase {
       $this->submitForm([
         'content_translation[status]' => $expected_status,
       ], 'Save');
+      $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 1]), [
+        'query' => ['language' => 'fi'],
+      ]);
       $this->assertSession()->fieldValueEquals('content_translation[status]', $expected_status);
     }
 
@@ -59,6 +62,9 @@ class UnitTranslationTest extends MigrationTestBase {
         $this->submitForm([
           'content_translation[status]' => $expected_status,
         ], 'Save');
+        $this->drupalGet(Url::fromRoute('entity.tpr_unit.edit_form', ['tpr_unit' => 1]), [
+          'query' => ['language' => $language],
+        ]);
         $this->assertSession()->fieldValueEquals('content_translation[status]', $expected_status);
       }
     }


### PR DESCRIPTION
How to test:

- Checkout this branch of the module: `composer require drupal/helfi_tpr:dev-UHF-2103_tpr_entity_form_redirect`
- Edit any TPR Unit or Service entity and save
- See how the browser redirects to the entity page and a confirmation message is displayed