### PR TITLE
UHF-2500: Change the print order on tpr service and tpr unit

### DIFF
--- a/templates/tpr-service.html.twig
+++ b/templates/tpr-service.html.twig
@@ -34,14 +34,14 @@
           </div>
         {% endif %}
 
-        {% block main_content %}
-        {% endblock main_content %}
-
         {% if content.errand_services|render %}
           <div class="service__errand-services">
             {{ content.errand_services }}
           </div>
         {% endif %}
+
+        {% block main_content %}
+        {% endblock main_content %}
       </div>
       {% if in_menu or sidebar_content %}
         <div class="service__sidebar">

--- a/templates/tpr-unit.html.twig
+++ b/templates/tpr-unit.html.twig
@@ -42,6 +42,10 @@
             {{ content.description }}
           </div>
         {% endif %}
+
+        {% block main_content %}
+        {% endblock main_content %}
+
         {% if content.service_map_embed|render %}
           <div class="unit__map">
             <label class="unit__map__label">
@@ -51,9 +55,6 @@
             {{ content.service_map_embed }}
           </div>
         {% endif %}
-
-        {% block main_content %}
-        {% endblock main_content %}
 
       </div>
 


### PR DESCRIPTION
How to test:

1. Require this branch to any instance you are running: `composer require drupal/helfi_tpr:dev-UHF-2500_change_print_order_on_service_and_unit`
2. If you don't have any units, services, errand services or service channels imported then you need to do that. 
  * `make shell`
  * Enable TPR module with configuration `drush en -y helfi_tpr_config`
  * Import units `MIGRATE_LIMIT=500 drush mim tpr_unit`
  * Import services `drush mim tpr_service`
  * Import errand servives `drush mim tpr_errand_service`
  * Import service channels `drush mim tpr_service_channel`
  * `drush cr`
  * `drush uli` and log into the site using the link.
3. Go to edit any unit that has a map in it (most of them have) and add some text to the "Upper content region". Save the unit and go view it.
4. The "Upper content region should be printed BEFORE the map unlike it was before.
5. Go to edit any service that has errand services attached to it. For example any of these should have those:
  * `fi/tpr-service/3641` (eservice, post, printable form)
  * `fi/tpr-service/6449` (eservice, website)
  * `fi/tpr-service/3005` (chat)
  * `fi/tpr-service/4641` (local)
  * `fi/tpr-service/2703` (eservice, email)
  * `fi/tpr-service/7629` (phone)
6. Add some content like text to the "Upper content region" of the service. Save the service and go view it.
7.  The "Upper content region should be printed AFTER the errand services unlike it was before.