### PR TITLE
UHF-2509: TPR Service links

### DIFF
--- a/templates/tpr-service.html.twig
+++ b/templates/tpr-service.html.twig
@@ -49,9 +49,9 @@
           {% endblock sidebar_block%}
 
           {% if content.links|render %}
-            <div class="service__links">
-              {{ 'Important links'|t }}
-              {{ content.links }}
+            <div class="sidebar-text sidebar-text--service-links has-title ">
+              <h2 class="sidebar-text__title">{{ 'Important links'|t }}</h2>
+              <div class="sidebar-text__text-content">{{ content.links }}</div>
             </div>
           {% endif %}
         </div>

--- a/templates/tpr-service.html.twig
+++ b/templates/tpr-service.html.twig
@@ -43,10 +43,17 @@
         {% block main_content %}
         {% endblock main_content %}
       </div>
-      {% if in_menu or sidebar_content %}
+      {% if in_menu or sidebar_content or content.links|render %}
         <div class="service__sidebar">
           {% block sidebar_block %}
           {% endblock sidebar_block%}
+
+          {% if content.links|render %}
+            <div class="service__links">
+              {{ 'Important links'|t }}
+              {{ content.links }}
+            </div>
+          {% endif %}
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
How to set up for testing:

- Set up a local environment
- Checkout this branch of the TPR module: `composer require drupal/helfi_tpr:dev-UHF-2509_tpr_service_links`
- Checkout the corresponding branch of the HDBT theme: `composer require drupal/helfi_hdbt:dev-UHF-2509_tpr_service_links`
  - If the above doesn't work, try the following (it may not work as there is no PR made of the branch):
    - `cd public/themes/contrib/hdbt`
    - `git fetch`
    - `git checkout UHF-2509_tpr_service_links`
- Import some TPR Services (if not already):
  - `make shell`
  - `drush mim tpr_service` 
- Clear cache: `make drush-cr`
- Access any TPR Service with links (for example "Asukaspysäköinti", ID 3621) → see the links in the sidebar