### PR TITLE
UHF-2838 fixed service path translations

### DIFF
--- a/helfi_tpr.tokens.inc
+++ b/helfi_tpr.tokens.inc
@@ -112,8 +112,11 @@ function helfi_tpr_tokens(
           $titles = [];
 
           foreach (array_reverse($parents) as $parent) {
-            $title = $menu_link_manager->createInstance($parent)->getTitle();
-            $titles[] = \Drupal::service('pathauto.alias_cleaner')->cleanString($title, $options);
+            $menu_link_item = $menu_link_manager->createInstance($parent);
+            $titles[] = \Drupal::service('pathauto.alias_cleaner')->cleanString(
+              token_menu_link_translated_title($menu_link_item, $options['langcode']),
+              $options
+            );
           }
 
           // Return the titles as a string separated with /'s.


### PR DESCRIPTION
Fixes the service entity paths.

Start with any existing environment (preferably with existing database)

1. If you you don't have existing test/prod environment database:
 - (just get the database, it makes this easier and faster and skip this first step)
 - import bunch of services, 
 - assign them to menu, remember the translations as well, 
 - publish the entities,  
 - run the bulk update for paths to break the paths.
 - Go check some of the paths for different service entity translations. The translations should be wrong.

2. If you use existing database, run "make fresh".

3. Run "composer require drupal/helfi_tpr:dev-UHF-2838_path_translation_fix"

4. Running "make drush-cr" should be enough at this point. Also make sure there are published service and service translations in database and the entities (and translations) are assigned to a menu.

5. Go to /admin/config/search/path/update_bulk
 - select "tpr services"
 - select "Regenerate URL aliases for all paths"
 - Run the bulk operation

Now go check some of the published services and their translations. 
- Every service and translation should have correct path with correct translation.