### PR TITLE
UHF-2834: Always use Finnish as service's default language

### DIFF
--- a/src/Plugin/migrate/source/ServiceRegister.php
+++ b/src/Plugin/migrate/source/ServiceRegister.php
@@ -68,19 +68,22 @@ class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPl
         break;
       }
 
-      $delta = 0;
       foreach (['fi', 'en', 'sv'] as $language) {
         $url = $this->buildCanonicalUrl(sprintf('%s?language=%s', $item['id'], $language));
 
         if (!$data = $this->getContent($url)) {
+          // If getting Finnish data was unsuccessful, do not get data for
+          // other languages.
+          if ($language === 'fi') {
+            break;
+          }
           continue;
         }
-        // Mark first item as default langcode.
-        if ($delta === 0) {
+
+        // Always use Finnish as service's default language.
+        if ($language === 'fi') {
           $data['default_langcode'] = TRUE;
         }
-        $delta++;
-
         $data['language'] = $language;
 
         yield $data;


### PR DESCRIPTION
There was a problem when importing services.

Assuming there was an existing service entity in Finnish with translations in Swedish and English. Then, if fetching the Finnish source data, for some reason, failed, the English version became the default one. This caused the Finnish version to disappear from the UI, as it was no longer included with the latest revision.

At this point, the English version had the entity references which were previously added to the Finnish version.

After this, when re-importing the service without failing to get the data, the Finnish version became once again the default language version. Now there were all three language versions, but the English translation had lost all its previously added entity references.

**How to test**

* Set up a local environment.
* Make sure you have some previously imported TPR services.
* Make sure at least some of the services are published, and those have some custom paragraph content added. Also make sure the services have all three language versions and Finnish is the default language.
* Get the changes for this module: `composer require drupal/helfi_tpr:dev-UHF-2834-service-default-language`
* Test that importing TPR services work by running:
  *  `drush migrate:import tpr_errand_service`
  *  `drush migrate:import tpr_service` (or `drush migrate:import tpr_service --idlist=<service_id>` where `<service_id>` is the ID of the service, if you don't want to import every service)
  *  `drush migrate:import tpr_service_channel`
* Check that running the migration did not change the services in some unexpected way. The default Finnish language nor the custom paragraph content should not be changed.