### PR TITLE
UHF-2908: Fix partial migrates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 env:
   SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
   SIMPLETEST_BASE_URL: "http://127.0.0.1:8080"
-  DRUPAL_CORE: 9.0.x
   MODULE_NAME: helfi_tpr
   SYMFONY_DEPRECATIONS_HELPER: disabled
 jobs:
@@ -11,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['8.0']
     container:
       image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}
 

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "php": "^8.0",
         "drupal/helfi_api_base": "*",
         "drupal/address": "~1.0",
         "drupal/readonly_field_widget": "^1.0",

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -484,3 +484,17 @@ function helfi_tpr_update_8026() : void {
       ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
   }
 }
+
+/**
+ * Drop migrate map tables to add second id map field.
+ */
+function helfi_tpr_update_8027() : void {
+  foreach (['unit', 'service', 'errand_service', 'service_channel'] as $type) {
+    $query = \Drupal::database()->schema();
+    $table = "migrate_map_tpr_$type";
+
+    if (!$query->fieldExists($table, 'sourceid2')) {
+      $query->dropTable($table);
+    }
+  }
+}

--- a/migrations/tpr_errand_service.yml
+++ b/migrations/tpr_errand_service.yml
@@ -12,6 +12,7 @@ source:
   plugin: tpr_service_register
   track_changes: true
   url: 'https://city-of-helsinki.github.io/drupal-tpr-aggregator/errandservices.json'
+  canonical_url: 'https://www.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/errandservice/'
 process:
   name: name
   id: id

--- a/migrations/tpr_errand_service.yml
+++ b/migrations/tpr_errand_service.yml
@@ -11,7 +11,7 @@ label: 'TPR errand service'
 source:
   plugin: tpr_service_register
   track_changes: true
-  url: 'https://www.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/errandservice/'
+  url: 'https://city-of-helsinki.github.io/drupal-tpr-aggregator/errandservices.json'
 process:
   name: name
   id: id

--- a/migrations/tpr_service.yml
+++ b/migrations/tpr_service.yml
@@ -11,7 +11,7 @@ label: 'TPR service'
 source:
   plugin: tpr_service_register
   track_changes: true
-  url: 'https://www.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/description/'
+  url: 'https://city-of-helsinki.github.io/drupal-tpr-aggregator/services.json'
 process:
   id: id
   name: title

--- a/migrations/tpr_service.yml
+++ b/migrations/tpr_service.yml
@@ -12,6 +12,7 @@ source:
   plugin: tpr_service_register
   track_changes: true
   url: 'https://city-of-helsinki.github.io/drupal-tpr-aggregator/services.json'
+  canonical_url: 'https://www.hel.fi/palvelukarttaws/rest/vpalvelurekisteri/description/'
 process:
   id: id
   name: title

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Field\Connection;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
 
 /**
@@ -34,7 +35,7 @@ final class OpeningHour extends Connection {
   public function build(): array {
     $build = [
       'name' => [
-        '#markup' => $this->get('name'),
+        '#markup' => Html::escape($this->get('name')),
       ],
     ];
 

--- a/src/Fixture/ErrandService.php
+++ b/src/Fixture/ErrandService.php
@@ -39,11 +39,8 @@ final class ErrandService extends FixtureBase {
       ['id' => 2],
       ['id' => 3],
     ];
-    $responses = [
-      new Response(200, [], json_encode($eservices)),
-    ];
 
-    foreach ($eservices as $service) {
+    foreach ($eservices as $key => $service) {
       $id = $service['id'];
 
       foreach (['fi', 'en', 'sv'] as $language) {
@@ -97,11 +94,13 @@ final class ErrandService extends FixtureBase {
         foreach ($this->getFields() as $field) {
           $service[$field] = sprintf('%s %s %s', $field, $language, $id);
         }
-        $responses[] = new Response(200, [], json_encode($service));
+        $eservices[$key][$language] = $service;
       }
     }
 
-    return $responses;
+    return [
+      new Response(200, [], json_encode($eservices)),
+    ];
   }
 
 }

--- a/src/Fixture/Service.php
+++ b/src/Fixture/Service.php
@@ -19,27 +19,23 @@ final class Service extends FixtureBase {
     $services = [
       [
         'id' => 1,
-        'title' => 'Service 1',
         'unit_ids' => ['1'],
       ],
       [
         'id' => 2,
-        'title' => 'Service 2',
       ],
       [
         'id' => 3,
-        'title' => 'Service 3',
       ],
     ];
-    $responses = [
-      new Response(200, [], json_encode($services)),
-    ];
 
-    foreach ($services as $service) {
+    foreach ($services as $key => $service) {
       $id = $service['id'];
 
       foreach (['fi', 'en', 'sv'] as $language) {
-        $item = array_merge($service, [
+        $services[$key][$language] = $service;
+
+        $services[$key][$language] += [
           'title' => sprintf('Service %s %s', $language, $id),
           'description_short' => sprintf('Description short %s %s', $language, $id),
           'description_long' => sprintf('Description long %s %s', $language, $id),
@@ -59,11 +55,12 @@ final class Service extends FixtureBase {
               'url' => sprintf('https://localhost/2/%s/%s', $language, $id),
             ],
           ],
-        ]);
-        $responses[] = new Response(200, [], json_encode($item));
+        ];
       }
     }
-    return $responses;
+    return [
+      new Response(200, [], json_encode($services)),
+    ];
   }
 
 }

--- a/src/Plugin/migrate/destination/Service.php
+++ b/src/Plugin/migrate/destination/Service.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Plugin\migrate\destination;
 
+use Drupal\helfi_api_base\Entity\RemoteEntityBase;
 use Drupal\helfi_tpr\Entity\Unit;
 use Drupal\migrate\Row;
 
@@ -19,16 +20,21 @@ final class Service extends TprDestinationBase {
   /**
    * {@inheritdoc}
    */
-  protected static function getEntityTypeId($plugin_id) {
+  protected static function getEntityTypeId($plugin_id) : string {
     return 'tpr_service';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getEntity(Row $row, array $old_destination_id_values) {
+  public function getEntity(Row $row, array $old_destination_id_values) : RemoteEntityBase {
     $entity = parent::getEntity($row, $old_destination_id_values);
-    $entity->setData('source', $row->getSource());
+
+    // Unit ids are not language specific so we can safely return early
+    // if we're not saving the first translation.
+    if (!$row->getSourceProperty('default_langcode')) {
+      return $entity;
+    }
 
     if ($unitIds = $row->getSourceProperty('unit_ids')) {
       $units = Unit::loadMultiple($unitIds);

--- a/src/Plugin/migrate/source/ServiceChannel.php
+++ b/src/Plugin/migrate/source/ServiceChannel.php
@@ -65,8 +65,14 @@ class ServiceChannel extends SourcePluginBase implements ContainerFactoryPluginI
    */
   public function getIds() : array {
     return [
-      'id' => ['type' => 'string'],
-      'language' => ['type' => 'string'],
+      'id' => [
+        'type' => 'string',
+        'entity_key' => 'id',
+      ],
+      'language' => [
+        'type' => 'string',
+        'entity_key' => 'langcode',
+      ],
     ];
   }
 

--- a/src/Plugin/migrate/source/ServiceChannel.php
+++ b/src/Plugin/migrate/source/ServiceChannel.php
@@ -63,8 +63,11 @@ class ServiceChannel extends SourcePluginBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  public function getIds() {
-    return ['id' => ['type' => 'string']];
+  public function getIds() : array {
+    return [
+      'id' => ['type' => 'string'],
+      'language' => ['type' => 'string'],
+    ];
   }
 
   /**

--- a/src/Plugin/migrate/source/ServiceMap.php
+++ b/src/Plugin/migrate/source/ServiceMap.php
@@ -34,15 +34,18 @@ class ServiceMap extends HttpSourcePluginBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  public function __toString() {
+  public function __toString() : string {
     return 'TprServiceMap';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getIds() {
-    return ['id' => ['type' => 'string']];
+  public function getIds() : array {
+    return [
+      'id' => ['type' => 'string'],
+      'language' => ['type' => 'string'],
+    ];
   }
 
   /**
@@ -58,7 +61,7 @@ class ServiceMap extends HttpSourcePluginBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  public function fields() {
+  public function fields() : array {
     return [];
   }
 

--- a/src/Plugin/migrate/source/ServiceMap.php
+++ b/src/Plugin/migrate/source/ServiceMap.php
@@ -6,7 +6,6 @@ namespace Drupal\helfi_tpr\Plugin\migrate\source;
 
 use Drupal\Component\Datetime\DateTimePlus;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
 
 /**
  * Source plugin for retrieving data from Tpr.
@@ -15,7 +14,7 @@ use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
  *   id = "tpr_service_map"
  * )
  */
-class ServiceMap extends HttpSourcePluginBase implements ContainerFactoryPluginInterface {
+class ServiceMap extends TprSourceBase implements ContainerFactoryPluginInterface {
 
   use ServiceMapTrait;
 
@@ -29,23 +28,8 @@ class ServiceMap extends HttpSourcePluginBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  protected bool $useRequestCache = FALSE;
-
-  /**
-   * {@inheritdoc}
-   */
   public function __toString() : string {
     return 'TprServiceMap';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getIds() : array {
-    return [
-      'id' => ['type' => 'string'],
-      'language' => ['type' => 'string'],
-    ];
   }
 
   /**
@@ -56,13 +40,6 @@ class ServiceMap extends HttpSourcePluginBase implements ContainerFactoryPluginI
       $this->count = count($this->getContent($this->configuration['url']));
     }
     return $this->count;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function fields() : array {
-    return [];
   }
 
   /**

--- a/src/Plugin/migrate/source/ServiceRegister.php
+++ b/src/Plugin/migrate/source/ServiceRegister.php
@@ -17,6 +17,11 @@ use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
 class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPluginInterface {
 
   /**
+   * {@inheritdoc}
+   */
+  protected bool $useRequestCache = FALSE;
+
+  /**
    * The total count.
    *
    * @var int
@@ -44,7 +49,10 @@ class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public function getIds() : array {
-    return ['id' => ['type' => 'string']];
+    return [
+      'id' => ['type' => 'string'],
+      'language' => ['type' => 'string'],
+    ];
   }
 
   /**
@@ -69,19 +77,17 @@ class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPl
       }
 
       foreach (['fi', 'en', 'sv'] as $language) {
-        $url = $this->buildCanonicalUrl(sprintf('%s?language=%s', $item['id'], $language));
-
-        if (!$data = $this->getContent($url)) {
-          // If getting Finnish data was unsuccessful, do not get data for
-          // other languages.
+        if (!$data = $item[$language]) {
           if ($language === 'fi') {
+            // If getting Finnish data was unsuccessful, do not get data for
+            // other languages.
             break;
           }
           continue;
         }
 
-        // Always use Finnish as service's default language.
         if ($language === 'fi') {
+          // Always use Finnish as service's default language.
           $data['default_langcode'] = TRUE;
         }
         $data['language'] = $language;

--- a/src/Plugin/migrate/source/ServiceRegister.php
+++ b/src/Plugin/migrate/source/ServiceRegister.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Drupal\helfi_tpr\Plugin\migrate\source;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
 
 /**
  * Source plugin for retrieving data from Tpr.
@@ -14,12 +13,7 @@ use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
  *   id = "tpr_service_register"
  * )
  */
-class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * {@inheritdoc}
-   */
-  protected bool $useRequestCache = FALSE;
+class ServiceRegister extends TprSourceBase implements ContainerFactoryPluginInterface {
 
   /**
    * The total count.
@@ -48,18 +42,11 @@ class ServiceRegister extends HttpSourcePluginBase implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
-  public function getIds() : array {
-    return [
-      'id' => ['type' => 'string'],
-      'language' => ['type' => 'string'],
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function fields() : array {
-    return [];
+  protected function getCanonicalBaseUrl() : string {
+    if (!isset($this->configuration['canonical_url'])) {
+      throw new \InvalidArgumentException('The "canonical_url" configuration is missing.');
+    }
+    return $this->configuration['canonical_url'];
   }
 
   /**

--- a/src/Plugin/migrate/source/TprSourceBase.php
+++ b/src/Plugin/migrate/source/TprSourceBase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\source;
+
+use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
+
+/**
+ * Base class for TPR sources.
+ */
+abstract class TprSourceBase extends HttpSourcePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected bool $useRequestCache = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() : array {
+    return [
+      'id' => [
+        'type' => 'string',
+      ],
+      'language' => [
+        'type' => 'string',
+        'entity_key' => 'langcode',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() : array {
+    return [];
+  }
+
+}

--- a/src/Plugin/migrate/source/Unit.php
+++ b/src/Plugin/migrate/source/Unit.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "tpr_unit",
  * )
  */
-class Unit extends HttpSourcePluginBase implements ContainerFactoryPluginInterface {
+class Unit extends TprSourceBase implements ContainerFactoryPluginInterface {
 
   use ServiceMapTrait;
 
@@ -63,23 +63,6 @@ class Unit extends HttpSourcePluginBase implements ContainerFactoryPluginInterfa
 
       yield from $this->normalizeMultilingualData($data);
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function fields() {
-    return [];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getIds() : array {
-    return [
-      'id' => ['type' => 'string'],
-      'language' => ['type' => 'string'],
-    ];
   }
 
 }

--- a/src/Plugin/migrate/source/Unit.php
+++ b/src/Plugin/migrate/source/Unit.php
@@ -75,8 +75,11 @@ class Unit extends HttpSourcePluginBase implements ContainerFactoryPluginInterfa
   /**
    * {@inheritdoc}
    */
-  public function getIds() {
-    return ['id' => ['type' => 'string']];
+  public function getIds() : array {
+    return [
+      'id' => ['type' => 'string'],
+      'language' => ['type' => 'string'],
+    ];
   }
 
 }

--- a/src/Plugin/migrate/source/Unit.php
+++ b/src/Plugin/migrate/source/Unit.php
@@ -6,7 +6,6 @@ namespace Drupal\helfi_tpr\Plugin\migrate\source;
 
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/fixtures/service.json
+++ b/tests/fixtures/service.json
@@ -1,0 +1,216 @@
+[
+  {
+    "id": 2773,
+    "fi": {
+      "id": 2773,
+      "main_description": true,
+      "service_id": 10004,
+      "title": "Perusopetus",
+      "name_synonyms": "peruskoulu, peruskoulut, kansakoulu, ala-aste, yläaste, koulu",
+      "description_short": "9-vuotisessa peruskoulussa saa yleissivistävän pohjakoulutuksen. Kaikkien Suomessa asuvien 7 vuotta täyttäneiden lasten on käytävä koulua tai suoritettava muutoin peruskoulun oppimäärä.",
+      "description_long": "9-vuotisessa peruskoulussa saa yleissivistävän pohjakoulutuksen. Kaikkien Suomessa asuvien 7 vuotta täyttäneiden lasten on käytävä koulua tai suoritettava muutoin peruskoulun oppimäärä. \n\nHelsingissä on sekä yhtenäisiä peruskouluja että ala- ja yläasteen kouluja. Ala-asteen kouluissa voi olla 1.-6. luokat tai 1.-4. luokat. Yläasteen kouluissa on 7.-9. luokat. Kaikille lapsille on koulupaikka omassa lähikoulussa.\n\nHelsingissä toimii kaupungin omien peruskoulujen rinnalla yksityisiä sopimuskouluja, yksityisiä kouluja ja valtion kouluja.",
+      "servicemap_url": "https:\/\/palvelukartta.hel.fi\/fi\/search?service_node=1097&organization=83e74666-0836-4c1d-948a-4b34a8b90301",
+      "general_description_id": "27d2f17f-085f-4686-82c7-c030cb6556ac",
+      "provided_languages": [
+        "fi",
+        "sv"
+      ],
+      "responsible_depts": [
+        "cc70d1d8-3ca7-416a-9ea7-27e6b7ce58a8"
+      ],
+      "target_groups": [
+        "CHILDREN_AND_FAMILIES",
+        "INDIVIDUALS",
+        "YOUTH"
+      ],
+      "life_events": [
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3012",
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3014",
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3015"
+      ],
+      "errand_services": [
+      ],
+      "exact_errand_services": [
+        4300
+      ],
+      "links": [
+        {
+          "type": "INTERNET",
+          "title": "Lisätietoa perusopetuksesta",
+          "url": "https:\/\/www.hel.fi\/Helsinki\/fi\/paivahoito-ja-koulutus\/perusopetus\/"
+        },
+        {
+          "type": "INTERNET",
+          "title": "Kouluhaku",
+          "url": "http:\/\/www.edu.hel.fi\/kouluhaku"
+        },
+        {
+          "type": "INTERNET",
+          "title": "Peruskoulut alueittain",
+          "url": "https:\/\/www.hel.fi\/peruskoulut\/fi\/alueet"
+        },
+        {
+          "type": "INTERNET",
+          "title": "Peruskoulut kartalla",
+          "url": "https:\/\/www.hel.fi\/peruskoulut\/fi\/kartalla"
+        }
+      ],
+      "availabilities": [
+      ],
+      "unit_ids": []
+    },
+    "en": {
+      "id": 2773,
+      "main_description": true,
+      "service_id": 10004,
+      "title": "Comprehensive education",
+      "description_short": "Comprehensive education lasts for 9 years. All the children living in Finland are subject to compulsory comprehensive education. Children usually complete their compulsory education at comprehensive school, unless they receive instruction in some other way. In most cases comprehensive education starts in the year when the child becomes seven years of age.",
+      "description_long": "Comprehensive education lasts for 9 years. All the children living in Finland are subject to compulsory comprehensive education. Children usually complete their compulsory education at comprehensive school, unless they receive instruction in some other way. In most cases comprehensive education starts in the year when the child becomes seven years of age. \n\nIn Helsinki there are comprehensive schools providing basic education in both primary and lower secondary levels (classes 1-9, primary level comprehensive schools(classes 1-4 or 1-6)and lower secondary level schools (classes 7-9). Every child is provided with a place in her\/his own local school. \n\nIn Helsinki there are schools maintained by the city, private contracting schools, private schools and state owned schools.",
+      "servicemap_url": "https:\/\/palvelukartta.hel.fi\/fi\/search?service_node=1097&organization=83e74666-0836-4c1d-948a-4b34a8b90301",
+      "general_description_id": "27d2f17f-085f-4686-82c7-c030cb6556ac",
+      "provided_languages": [
+        "fi",
+        "sv"
+      ],
+      "responsible_depts": [
+        "cc70d1d8-3ca7-416a-9ea7-27e6b7ce58a8"
+      ],
+      "target_groups": [
+        "CHILDREN_AND_FAMILIES",
+        "INDIVIDUALS",
+        "YOUTH"
+      ],
+      "life_events": [
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3012",
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3014",
+        "http:\/\/urn.fi\/URN:NBN:fi:au:ptvl:v3015"
+      ],
+      "errand_services": [
+      ],
+      "exact_errand_services": [
+      ],
+      "links": [
+      ],
+      "availabilities": [
+      ],
+      "unit_ids": []
+    },
+    "sv": [
+    ]
+  },
+  {
+    "id": 3006,
+    "fi": {
+      "id": 3006,
+      "main_description": false,
+      "service_id": 10004,
+      "title": "Koulun kerhotoiminta",
+      "name_synonyms": "kerho, kerhot, harrastuskerho, harrastuskerhot, koulun kerho, koulun kerhot",
+      "description_short": "Helsinkiläisille peruskoululaisille järjestetään koulupäivän yhteydessä kerhotoimintaa. Oppilaat voivat osallistua kerhotoiminnan suunnitteluun ja kehittämiseen muun muassa koulujen oppilaskuntien kautta. Koulun kerhotoimintaa voidaan järjestää joko omalla henkilökunnalla tai ostettuna ulkopuoliselta toimijalta (osallistujille maksutonta). Tämän lisäksi koululla voi olla muutakin kaupungin ulkopuolisen toimijan järjestämää kerhotoimintaa (kohtuulliset osallistumiskustannukset). Koulukohtainen kerhotarjonta on koulujen verkkosivuilla kohdassa \"Meidän koulu\" > Kerho- ja harrastustoiminta.",
+      "description_long": "Helsinkiläisille peruskoululaisille järjestetään koulupäivän yhteydessä kerhotoimintaa. Oppilaat voivat osallistua kerhotoiminnan suunnitteluun ja kehittämiseen muun muassa koulujen oppilaskuntien kautta. Koulun kerhotoimintaa voidaan järjestää joko omalla henkilökunnalla tai ostettuna ulkopuoliselta toimijalta (osallistujille maksutonta). Tämän lisäksi koululla voi olla muutakin kaupungin ulkopuolisen toimijan järjestämää kerhotoimintaa (kohtuulliset osallistumiskustannukset). Koulukohtainen kerhotarjonta on koulujen verkkosivuilla kohdassa \"Meidän koulu\" > Kerho- ja harrastustoiminta.\n",
+      "prerequisites": "Helsinkiläiset perusopetuksessa olevat oppilaat.",
+      "general_description_id": "452bdcf1-4420-4892-a1dc-36830815580e",
+      "provided_languages": [
+        "fi",
+        "sv"
+      ],
+      "responsible_depts": [
+        "cc70d1d8-3ca7-416a-9ea7-27e6b7ce58a8"
+      ],
+      "target_groups": [
+        "CHILDREN_AND_FAMILIES",
+        "YOUTH"
+      ],
+      "life_events": [
+      ],
+      "errand_services": [
+      ],
+      "exact_errand_services": [
+      ],
+      "links": [
+        {
+          "type": "INTERNET",
+          "title": "Kouluhaku",
+          "url": "http:\/\/www.edu.hel.fi\/kouluhaku",
+          "file_format": "HTML"
+        }
+      ],
+      "availabilities": [
+      ],
+      "unit_ids": []
+    },
+    "en": {
+      "id": 3006,
+      "main_description": false,
+      "service_id": 10004,
+      "title": "School clubs",
+      "description_short": "Club activities are organised for the comprehensive school pupils of Helsinki in connection with the school day. Pupils can participate in the planning and development of these activities, for example, through the students' unions of the schools. Schools' club activities can either be organised by the school's own staff or bought from external operators (free of charge for the participants). In addition to this, schools may have other club activities organised by operators outside of the City (moderate participation costs). The school-specific club selection is available on each school's website under 'Meidän koulu' > Kerho- ja harrastustoiminta. Pupils in morning and afternoon activities can participate in the club activities at the school.",
+      "description_long": "Club activities are organised for the comprehensive school pupils of Helsinki in connection with the school day. Pupils can participate in the planning and development of these activities, for example, through the students' unions of the schools. Schools' club activities can either be organised by the school's own staff or bought from external operators (free of charge for the participants). In addition to this, schools may have other club activities organised by operators outside of the City (moderate participation costs). The school-specific club selection is available on each school's website under 'Meidän koulu' > Kerho- ja harrastustoiminta. Pupils in morning and afternoon activities can participate in the club activities at the school.",
+      "information": "Find more information from your school",
+      "general_description_id": "452bdcf1-4420-4892-a1dc-36830815580e",
+      "provided_languages": [
+        "fi",
+        "sv"
+      ],
+      "responsible_depts": [
+        "cc70d1d8-3ca7-416a-9ea7-27e6b7ce58a8"
+      ],
+      "target_groups": [
+        "CHILDREN_AND_FAMILIES",
+        "YOUTH"
+      ],
+      "life_events": [
+      ],
+      "errand_services": [
+      ],
+      "exact_errand_services": [
+      ],
+      "links": [
+        {
+          "type": "INTERNET",
+          "title": "Search Schools",
+          "url": "http:\/\/www.edu.hel.fi\/schoolsearch"
+        }
+      ],
+      "availabilities": [
+      ],
+      "unit_ids": []
+    },
+    "sv": {
+      "id": 3006,
+      "main_description": false,
+      "service_id": 10004,
+      "title": "Klubbverksamhet i skolan",
+      "description_short": "I samband med skoldagen arrangeras klubbverksamhet åt Helsingforsiska grundskoleelever. Eleverna kan delta i planeringen och utvecklingen av klubbverksamheten bland annat via skolornas elevkårer. Skolans klubbverksamhet kan antingen arrangeras med den egna personalen, eller genom en utomstående inköpt aktör (avgiftsfri för deltagarna). Dessutom kan det i skolan finnas annan klubbverksamhet som arrangeras av en aktör utanför staden (med skäliga kostnader för deltagande). Det skolspecifika utbudet av klubbverksamhet hittas på skolornas webbplats vid punkten \"Vår skola\" > Klubb- och hobbyverksamhet. Elever i morgon- och eftermiddagsverksamhet kan delta i klubbverksamheten som erbjuds på skolan.\n",
+      "description_long": "I samband med skoldagen arrangeras klubbverksamhet åt Helsingforsiska grundskoleelever. Eleverna kan delta i planeringen och utvecklingen av klubbverksamheten bland annat via skolornas elevkårer. Skolans klubbverksamhet kan antingen arrangeras med den egna personalen, eller genom en utomstående inköpt aktör (avgiftsfri för deltagarna). Dessutom kan det i skolan finnas annan klubbverksamhet som arrangeras av en aktör utanför staden (med skäliga kostnader för deltagande). Det skolspecifika utbudet av klubbverksamhet hittas på skolornas webbplats vid punkten \"Vår skola\" > Klubb- och hobbyverksamhet. Elever i morgon- och eftermiddagsverksamhet kan delta i klubbverksamheten som erbjuds på skolan.\n",
+      "general_description_id": "452bdcf1-4420-4892-a1dc-36830815580e",
+      "provided_languages": [
+        "fi",
+        "sv"
+      ],
+      "responsible_depts": [
+        "cc70d1d8-3ca7-416a-9ea7-27e6b7ce58a8"
+      ],
+      "target_groups": [
+        "CHILDREN_AND_FAMILIES",
+        "YOUTH"
+      ],
+      "life_events": [
+      ],
+      "errand_services": [
+      ],
+      "exact_errand_services": [
+      ],
+      "links": [
+        {
+          "type": "INTERNET",
+          "title": "Sök skolor",
+          "url": "http:\/\/www.edu.hel.fi\/sokskolor"
+        }
+      ],
+      "availabilities": [
+      ],
+      "unit_ids": []
+    }
+  }
+]

--- a/tests/src/Functional/ListTestBase.php
+++ b/tests/src/Functional/ListTestBase.php
@@ -66,4 +66,20 @@ abstract class ListTestBase extends MigrationTestBase {
     $this->assertSession()->pageTextContains('No results found.');
   }
 
+  /**
+   * Asserts that the item is published or unpublished.
+   *
+   * @param int $nthChild
+   *   The nth child.
+   * @param bool $published
+   *   TRUE if expected to be published.
+   */
+  protected function assertPublished(int $nthChild, bool $published) : void {
+    $element = $this->getSession()
+      ->getPage()
+      ->find('css', "table tbody tr:nth-of-type($nthChild) .views-field-content-translation-status");
+
+    $this->assertEquals($published ? 'Published' : 'Unpublished', $element->getText());
+  }
+
 }

--- a/tests/src/Functional/ListTestBase.php
+++ b/tests/src/Functional/ListTestBase.php
@@ -67,6 +67,38 @@ abstract class ListTestBase extends MigrationTestBase {
   }
 
   /**
+   * Make sure publish action works.
+   *
+   * @param string $migrationId
+   *   The migration id.
+   * @param array $query
+   *   The query parameters.
+   */
+  protected function assertPublishAction(string $migrationId, array $query) : void {
+    $this->drupalGet($this->adminListPath, [
+      'query' => $query,
+    ]);
+    // Make sure we can use actions to publish and unpublish content.
+    $actions = [
+      "{$migrationId}_publish_action" => TRUE,
+      "{$migrationId}_unpublish_action" => FALSE,
+    ];
+
+    foreach ($actions as $action => $published) {
+      $form_data = [
+        'action' => $action,
+        $migrationId . '_bulk_form[0]' => 1,
+        $migrationId . '_bulk_form[1]' => 1,
+      ];
+      $this->submitForm($form_data, 'Apply to selected items');
+
+      for ($i = 1; $i <= 2; $i++) {
+        $this->assertPublished($i, $published);
+      }
+    }
+  }
+
+  /**
    * Asserts that the item is published or unpublished.
    *
    * @param int $nthChild

--- a/tests/src/Functional/ServiceListTest.php
+++ b/tests/src/Functional/ServiceListTest.php
@@ -69,14 +69,16 @@ class ServiceListTest extends ListTestBase {
 
     // Make sure we can run 'update' action on multiple entities.
     Service::load('2773')->set('name', 'Test 1')->save();
+    $query = [
+      'language' => 'fi',
+      'langcode' => 'fi',
+      'order' => 'changed',
+      'sort' => 'desc',
+    ];
     $this->drupalGet($this->adminListPath, [
-      'query' => [
-        'language' => 'fi',
-        'langcode' => 'fi',
-        'order' => 'changed',
-        'sort' => 'desc',
-      ],
+      'query' => $query,
     ]);
+
     $this->assertSession()->pageTextContains('Test 1');
     $this->assertSession()->pageTextContains('Koulun kerhotoiminta');
 
@@ -93,23 +95,7 @@ class ServiceListTest extends ListTestBase {
     $this->assertSession()->pageTextContains('Koulun kerhotoiminta');
 
     // Make sure we can use actions to publish and unpublish content.
-    $actions = [
-      'tpr_service_publish_action' => TRUE,
-      'tpr_service_unpublish_action' => FALSE,
-    ];
-
-    foreach ($actions as $action => $published) {
-      $form_data = [
-        'action' => $action,
-        'tpr_service_bulk_form[0]' => 1,
-        'tpr_service_bulk_form[1]' => 1,
-      ];
-      $this->submitForm($form_data, 'Apply to selected items');
-
-      for ($i = 1; $i <= 2; $i++) {
-        $this->assertPublished($i, $published);
-      }
-    }
+    $this->assertPublishAction('tpr_service', $query);
   }
 
 }

--- a/tests/src/Functional/ServiceListTest.php
+++ b/tests/src/Functional/ServiceListTest.php
@@ -4,37 +4,35 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tpr\Functional;
 
-use Drupal\helfi_tpr\Entity\Unit;
+use Drupal\helfi_tpr\Entity\Service;
 use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * Tests Unit entity's list functionality.
+ * Tests Service entity's list functionality.
  *
  * @group helfi_tpr
  */
-class UnitListTest extends ListTestBase {
+class ServiceListTest extends ListTestBase {
 
   use ApiTestTrait;
 
   /**
-   * Migrates the tpr unit entities.
+   * Migrates the tpr service entities.
    */
   private function runMigrate() : void {
-    $units = $this->getFixture('helfi_tpr', 'unit.json');
+    $fixture = $this->getFixture('helfi_tpr', 'service.json');
     $responses = [
-      new Response(200, [], $units),
+      new Response(200, [], $fixture),
     ];
 
-    foreach (json_decode($units, TRUE) as $unit) {
-      $responses[] = new Response(200, [], json_encode($unit));
-      // Connections and accessibility sentences requests.
-      $responses[] = new Response(200, [], json_encode([]));
-      $responses[] = new Response(200, [], json_encode([]));
+    foreach (json_decode($fixture, TRUE) as $item) {
+      // Update actions.
+      $responses[] = new Response(200, [], json_encode($item));
     }
 
     $this->container->set('http_client', $this->createMockHttpClient($responses));
-    $this->executeMigration('tpr_unit');
+    $this->executeMigration('tpr_service');
   }
 
   /**
@@ -44,23 +42,23 @@ class UnitListTest extends ListTestBase {
     parent::setUp();
     $this->listPermissions = [
       'access remote entities overview',
-      'administer tpr_unit',
+      'administer tpr_service',
     ];
-    $this->adminListPath = '/admin/content/integrations/tpr-unit';
+    $this->adminListPath = '/admin/content/integrations/tpr-service';
   }
 
   /**
-   * Tests list view permissions, and viewing, updating, and publishing units.
+   * Tests list view permissions, updating, and publishing services.
    */
   public function testList() : void {
     parent::testList();
 
     // Migrate entities and make sure we can see all entities from fixture.
     $this->runMigrate();
-    $expected = ['fi' => 6, 'en' => 0, 'sv' => 4];
+    $expected = ['fi' => 2, 'en' => 2, 'sv' => 1];
 
     foreach ($expected as $language => $total) {
-      $this->drupalGet('/admin/content/integrations/tpr-unit', [
+      $this->drupalGet($this->adminListPath, [
         'query' => [
           'langcode' => $language,
           'language' => $language,
@@ -70,9 +68,8 @@ class UnitListTest extends ListTestBase {
     }
 
     // Make sure we can run 'update' action on multiple entities.
-    Unit::load('22736')->set('name', 'Test 1')->save();
-    Unit::load('57331')->set('name', 'Test 2')->save();
-    $this->drupalGet('/admin/content/integrations/tpr-unit', [
+    Service::load('2773')->set('name', 'Test 1')->save();
+    $this->drupalGet($this->adminListPath, [
       'query' => [
         'language' => 'fi',
         'langcode' => 'fi',
@@ -81,33 +78,31 @@ class UnitListTest extends ListTestBase {
       ],
     ]);
     $this->assertSession()->pageTextContains('Test 1');
-    $this->assertSession()->pageTextContains('Test 2');
+    $this->assertSession()->pageTextContains('Koulun kerhotoiminta');
 
     $form_data = [
-      'action' => 'tpr_unit_update_action',
+      'action' => 'tpr_service_update_action',
       // The list is sorted by changed timestamp so our updated entities
       // should be at the top of the list.
-      'tpr_unit_bulk_form[0]' => 1,
-      'tpr_unit_bulk_form[1]' => 1,
+      'tpr_service_bulk_form[0]' => 1,
     ];
     $this->submitForm($form_data, 'Apply to selected items');
 
     $this->assertSession()->pageTextNotContains('Test 1');
-    $this->assertSession()->pageTextNotContains('Test 2');
-    $this->assertSession()->pageTextContains('Esteetön testireitti / Leppävaara');
-    $this->assertSession()->pageTextContains('InnoOmnia');
+    $this->assertSession()->pageTextContains('Perusopetus');
+    $this->assertSession()->pageTextContains('Koulun kerhotoiminta');
 
     // Make sure we can use actions to publish and unpublish content.
     $actions = [
-      'tpr_unit_publish_action' => TRUE,
-      'tpr_unit_unpublish_action' => FALSE,
+      'tpr_service_publish_action' => TRUE,
+      'tpr_service_unpublish_action' => FALSE,
     ];
 
     foreach ($actions as $action => $published) {
       $form_data = [
         'action' => $action,
-        'tpr_unit_bulk_form[0]' => 1,
-        'tpr_unit_bulk_form[1]' => 1,
+        'tpr_service_bulk_form[0]' => 1,
+        'tpr_service_bulk_form[1]' => 1,
       ];
       $this->submitForm($form_data, 'Apply to selected items');
 

--- a/tests/src/Functional/UnitListTest.php
+++ b/tests/src/Functional/UnitListTest.php
@@ -60,7 +60,7 @@ class UnitListTest extends ListTestBase {
     $expected = ['fi' => 6, 'en' => 0, 'sv' => 4];
 
     foreach ($expected as $language => $total) {
-      $this->drupalGet('/admin/content/integrations/tpr-unit', [
+      $this->drupalGet($this->adminListPath, [
         'query' => [
           'langcode' => $language,
           'language' => $language,
@@ -72,13 +72,14 @@ class UnitListTest extends ListTestBase {
     // Make sure we can run 'update' action on multiple entities.
     Unit::load('22736')->set('name', 'Test 1')->save();
     Unit::load('57331')->set('name', 'Test 2')->save();
-    $this->drupalGet('/admin/content/integrations/tpr-unit', [
-      'query' => [
-        'language' => 'fi',
-        'langcode' => 'fi',
-        'order' => 'changed',
-        'sort' => 'desc',
-      ],
+    $query = [
+      'language' => 'fi',
+      'langcode' => 'fi',
+      'order' => 'changed',
+      'sort' => 'desc',
+    ];
+    $this->drupalGet($this->adminListPath, [
+      'query' => $query,
     ]);
     $this->assertSession()->pageTextContains('Test 1');
     $this->assertSession()->pageTextContains('Test 2');
@@ -98,23 +99,7 @@ class UnitListTest extends ListTestBase {
     $this->assertSession()->pageTextContains('InnoOmnia');
 
     // Make sure we can use actions to publish and unpublish content.
-    $actions = [
-      'tpr_unit_publish_action' => TRUE,
-      'tpr_unit_unpublish_action' => FALSE,
-    ];
-
-    foreach ($actions as $action => $published) {
-      $form_data = [
-        'action' => $action,
-        'tpr_unit_bulk_form[0]' => 1,
-        'tpr_unit_bulk_form[1]' => 1,
-      ];
-      $this->submitForm($form_data, 'Apply to selected items');
-
-      for ($i = 1; $i <= 2; $i++) {
-        $this->assertPublished($i, $published);
-      }
-    }
+    $this->assertPublishAction('tpr_unit', $query);
   }
 
 }

--- a/tests/src/Kernel/MigrationTestBase.php
+++ b/tests/src/Kernel/MigrationTestBase.php
@@ -47,4 +47,55 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
     $this->installConfig(['helfi_tpr']);
   }
 
+  /**
+   * Gets the row hash for given row.
+   *
+   * @param string $migrationId
+   *   The migration id.
+   * @param int|string $sourceId
+   *   The source id.
+   * @param string $language
+   *   The language.
+   *
+   * @return string|null
+   *   The migration hash.
+   */
+  protected function getMigrateMapRowHash(
+    string $migrationId,
+    int|string $sourceId,
+    string $language
+  ) : ? string {
+    /** @var \Drupal\Core\Database\Connection $database */
+    $database = $this->container->get('database');
+    $result = $database->select('migrate_map_' . $migrationId, 'm')
+      ->fields('m', ['hash'])
+      ->condition('sourceid1', $sourceId)
+      ->condition('sourceid2', $language)
+      ->execute()
+      ->fetchObject();
+
+    return $result->hash ?? NULL;
+  }
+
+  /**
+   * Compares given row hash against previous row hash.
+   *
+   * @param string $migrationId
+   *   The migration id.
+   * @param string $expected
+   *   The expected hash.
+   * @param int|string $sourceId
+   *   The source id.
+   * @param string $language
+   *   The language.
+   */
+  protected function assertMigrateMapRowHash(
+    string $migrationId,
+    string $expected,
+    int|string $sourceId,
+    string $language
+  ) {
+    $this->assertEquals($expected, $this->getMigrateMapRowHash($migrationId, $sourceId, $language));
+  }
+
 }


### PR DESCRIPTION
### 1. Fixed `track_changes` source plugin setting

The `Row->changed()` check has been broken for quite a while already, making migrations to update entities even when there are no new changes.  This should massively speed up any subsequent migrations and make `PARTIAL_MIGRATE` functionality pretty much obsolete.

### 2. Save unit ids only for first translation

At the moment unit ids are saved three times (once for every translation).

### 3. Use aggregated service and errand service data

I made a small service that aggregates TPR service and errand service data into a big JSON dump. Currently every instance makes ~2000 requests per migration to TPR's service endpoint. This should speed up both service migrations by eliminating need to create three requests per entity (one for each language).

See: https://github.com/City-of-Helsinki/drupal-tpr-aggregator

To test this:

- `drush updb`
- `drush cr`
- Run all migrations: `drush mim tpr_unit`, `drush mim tpr_service`, `drush mim tpr_errand_service`, `drush mim tpr_service_channel`
- Re-run  all migrations and they should be really fast