### PR TITLE
UHF-2528: unit_search view sorting alter

### DIFF
--- a/helfi_tpr.views_execution.inc
+++ b/helfi_tpr.views_execution.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Views alter for helfi_tpr.
+ */
+
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function helfi_tpr_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() == 'unit_search') {
+    // Use the CASE function from helfi_tpr_views_pre_execute() for sorting.
+    $query->orderby[0]['field'] = 'name_sort';
+    $query->orderby[0]['direction'] = 'ASC';
+  }
+}
+
+/**
+ * Implements hook_views_pre_execute().
+ */
+function helfi_tpr_views_pre_execute(ViewExecutable $view) {
+  if ($view->id() == 'unit_search') {
+    // CASE function for using the name_override field as default for sorting.
+    // If that field is empty, use the name field.
+    $view->build_info['query']->addExpression('CASE WHEN tpr_unit_field_data.name_override IS NULL THEN tpr_unit_field_data.name ELSE tpr_unit_field_data.name_override END', 'name_sort');
+  }
+}

--- a/helfi_tpr.views_execution.inc
+++ b/helfi_tpr.views_execution.inc
@@ -26,6 +26,11 @@ function helfi_tpr_views_pre_execute(ViewExecutable $view) {
   if ($view->id() == 'unit_search') {
     // CASE function for using the name_override field as default for sorting.
     // If that field is empty, use the name field.
-    $view->build_info['query']->addExpression('CASE WHEN tpr_unit_field_data.name_override IS NULL THEN tpr_unit_field_data.name ELSE tpr_unit_field_data.name_override END', 'name_sort');
+    $view->build_info['query']->addExpression('
+      CASE
+        WHEN tpr_unit_field_data.name_override IS NULL THEN tpr_unit_field_data.name
+        ELSE tpr_unit_field_data.name_override
+      END', 'name_sort'
+    );
   }
 }


### PR DESCRIPTION
Using the `name_override` field as a default for sorting. If that field is empty, use the `name` field.

To enable correct sorting of names with Scandinavian characters, see this PR: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/214

How to test:

1. Set up SOTE instance & checkout this branch of the module: `composer require drupal/helfi_tpr:dev-UHF-2528_unit_search_sorting`
2. Import some TPR Units
  2.1 `make shell`
  2.2 `MIGRATE_LIMIT=100 drush mim tpr_unit`
3. Publish some (or all) of the units
4. Create a content page and add Unit search paragraph with some units
5. See how the units are sorted alphabetically by title
6. Edit one of the units and change the `Override: name` to something else
7. See the page with the unit search again and see how the list is ordered so that the unit with the overridden name is in the correct place