### PR TITLE
UHF-2528: sorting fix also for service_units view

### DIFF
--- a/helfi_tpr.views_execution.inc
+++ b/helfi_tpr.views_execution.inc
@@ -12,7 +12,7 @@ use Drupal\views\ViewExecutable;
  * Implements hook_views_query_alter().
  */
 function helfi_tpr_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  if ($view->id() == 'unit_search') {
+  if ($view->id() == 'unit_search' || $view->id() == 'service_units') {
     // Use the CASE function from helfi_tpr_views_pre_execute() for sorting.
     $query->orderby[0]['field'] = 'name_sort';
     $query->orderby[0]['direction'] = 'ASC';
@@ -23,7 +23,7 @@ function helfi_tpr_views_query_alter(ViewExecutable $view, QueryPluginBase $quer
  * Implements hook_views_pre_execute().
  */
 function helfi_tpr_views_pre_execute(ViewExecutable $view) {
-  if ($view->id() == 'unit_search') {
+  if ($view->id() == 'unit_search' || $view->id() == 'service_units') {
     // CASE function for using the name_override field as default for sorting.
     // If that field is empty, use the name field.
     $view->build_info['query']->addExpression('


### PR DESCRIPTION
Similar fix for Service units view as this PR is for Unit search: https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/75

How to test:

- Set up SOTE instance and checkout this branch: `composer require drupal/helfi_tpr:dev-UHF-2528_service_unit_list_sorting`
- Import TPR Services: `drush mim tpr_service` and some TPR Units `MIGRATE_LIMIT=100 drush mim tpr_unit`
- Publish all of the imported TPR Units to make them visible on the TPR Service pages
- Find a TPR Service that has some of the published TPR Units (for example TPR Service ID 7341 should have libraries listed)
- See how the units are sorted alphabetically by title under "Palvelupaikat"
- Edit one of the units and change the `Override: name` to something else
- See the service page with the unit list again and see how the list is ordered so that the unit with the overridden name is in the correct place 