### PR TITLE
UHF-3254: unit search/list view collation alter

### DIFF
--- a/helfi_tpr.views_execution.inc
+++ b/helfi_tpr.views_execution.inc
@@ -30,7 +30,7 @@ function helfi_tpr_views_pre_execute(ViewExecutable $view) {
       CASE
         WHEN tpr_unit_field_data.name_override IS NULL THEN tpr_unit_field_data.name
         ELSE tpr_unit_field_data.name_override
-      END', 'name_sort'
+      END COLLATE utf8mb4_swedish_ci', 'name_sort'
     );
   }
 }


### PR DESCRIPTION
How to test:

- Set up SOTE instance
- Checkout this branch of the module: `composer require drupal/helfi_tpr:dev-UHF-3254_unit_list_view_collation_alter`
- Import some TPR Units
  - `make shell`
  - `MIGRATE_LIMIT=100 drush mim tpr_unit`
- Publish some (or all) of the units
- Create a content page and add Unit search paragraph with some units starting that have Å, Ö or Ä as the first letter of their name (Åggelby, Östersundom, etc.), OR edit some units and make their "Override: Name" start with one of those letters
- See how the units are sorted alphabetically by title