### PR TITLE
UHF-2604: Ontology word details

### DIFF
--- a/config/install/language.content_settings.tpr_ontology_word_details.tpr_ontology_word_details.yml
+++ b/config/install/language.content_settings.tpr_ontology_word_details.tpr_ontology_word_details.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - helfi_tpr
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: tpr_ontology_word_details.tpr_ontology_word_details
+target_entity_type_id: tpr_ontology_word_details
+target_bundle: tpr_ontology_word_details
+default_langcode: site_default
+language_alterable: true

--- a/config/schema/helfi_tpr.schema.yml
+++ b/config/schema/helfi_tpr.schema.yml
@@ -33,3 +33,13 @@ field.value.tpr_connection:
     value:
       type: label
       label: Value
+
+# Schema definition for emphasis filter.
+views.filter.emphasis_filter:
+  type: views.filter.in_operator
+  label: 'Allowed clarifications'
+
+# Schema definition for educational mission filter.
+views.filter.educational_mission_filter:
+  type: views.filter.in_operator
+  label: 'Allowed clarifications'

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -538,3 +538,12 @@ function helfi_tpr_update_8029() : void {
       ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
   }
 }
+
+/**
+ * Install tpr_ontology_word_details entity type.
+ */
+function helfi_tpr_update_8030() : void {
+  $manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('tpr_ontology_word_details');
+  $manager->installEntityType($entity_type);
+}

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -12,6 +12,60 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
+ * Helper function to get the content translation field definitions.
+ *
+ * @return array
+ */
+function _helfi_tpr_get_content_translation_fields(): array {
+  $definitions['content_translation_source'] = BaseFieldDefinition::create('language')
+    ->setLabel(t('Translation source'))
+    ->setDescription(t('The source language from which this translation was created.'))
+    ->setDefaultValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
+    ->setInitialValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
+    ->setRevisionable(TRUE)
+    ->setTranslatable(TRUE);
+
+  $definitions['content_translation_outdated'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(t('Translation outdated'))
+    ->setDescription(t('A boolean indicating whether this translation needs to be updated.'))
+    ->setDefaultValue(FALSE)
+    ->setInitialValue(FALSE)
+    ->setRevisionable(TRUE)
+    ->setTranslatable(TRUE);
+
+  $definitions['content_translation_uid'] = BaseFieldDefinition::create('entity_reference')
+    ->setLabel(t('Translation author'))
+    ->setDescription(t('The author of this translation.'))
+    ->setSetting('target_type', 'user')
+    ->setSetting('handler', 'default')
+    ->setRevisionable(TRUE)
+    ->setDefaultValueCallback(ContentTranslationHandler::class . '::getDefaultOwnerId')
+    ->setTranslatable(TRUE);
+
+  $definitions['content_translation_status'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(t('Translation status'))
+    ->setDescription(t('A boolean indicating whether the translation is visible to non-translators.'))
+    ->setDefaultValue(TRUE)
+    ->setInitialValue(TRUE)
+    ->setRevisionable(TRUE)
+    ->setTranslatable(TRUE);
+
+  $definitions['content_translation_created'] = BaseFieldDefinition::create('created')
+    ->setLabel(t('Translation created time'))
+    ->setDescription(t('The Unix timestamp when the translation was created.'))
+    ->setRevisionable(TRUE)
+    ->setTranslatable(TRUE);
+
+  $definitions['content_translation_changed'] = BaseFieldDefinition::create('changed')
+    ->setLabel(t('Translation changed time'))
+    ->setDescription(t('The Unix timestamp when the translation was most recently saved.'))
+    ->setRevisionable(TRUE)
+    ->setTranslatable(TRUE);
+
+  return $definitions;
+}
+
+/**
  * Installs the service entity type.
  */
 function helfi_tpr_update_8001() : void {
@@ -165,50 +219,7 @@ function helfi_tpr_update_8008() : void {
  * Installs content translation fields for errand services and channels.
  */
 function helfi_tpr_update_8010() : void {
-  $definitions['content_translation_source'] = BaseFieldDefinition::create('language')
-    ->setLabel(t('Translation source'))
-    ->setDescription(t('The source language from which this translation was created.'))
-    ->setDefaultValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
-    ->setInitialValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
-    ->setRevisionable(TRUE)
-    ->setTranslatable(TRUE);
-
-  $definitions['content_translation_outdated'] = BaseFieldDefinition::create('boolean')
-    ->setLabel(t('Translation outdated'))
-    ->setDescription(t('A boolean indicating whether this translation needs to be updated.'))
-    ->setDefaultValue(FALSE)
-    ->setInitialValue(FALSE)
-    ->setRevisionable(TRUE)
-    ->setTranslatable(TRUE);
-
-  $definitions['content_translation_uid'] = BaseFieldDefinition::create('entity_reference')
-    ->setLabel(t('Translation author'))
-    ->setDescription(t('The author of this translation.'))
-    ->setSetting('target_type', 'user')
-    ->setSetting('handler', 'default')
-    ->setRevisionable(TRUE)
-    ->setDefaultValueCallback(ContentTranslationHandler::class . '::getDefaultOwnerId')
-    ->setTranslatable(TRUE);
-
-  $definitions['content_translation_status'] = BaseFieldDefinition::create('boolean')
-    ->setLabel(t('Translation status'))
-    ->setDescription(t('A boolean indicating whether the translation is visible to non-translators.'))
-    ->setDefaultValue(TRUE)
-    ->setInitialValue(TRUE)
-    ->setRevisionable(TRUE)
-    ->setTranslatable(TRUE);
-
-  $definitions['content_translation_created'] = BaseFieldDefinition::create('created')
-    ->setLabel(t('Translation created time'))
-    ->setDescription(t('The Unix timestamp when the translation was created.'))
-    ->setRevisionable(TRUE)
-    ->setTranslatable(TRUE);
-
-  $definitions['content_translation_changed'] = BaseFieldDefinition::create('changed')
-    ->setLabel(t('Translation changed time'))
-    ->setDescription(t('The Unix timestamp when the translation was most recently saved.'))
-    ->setRevisionable(TRUE)
-    ->setTranslatable(TRUE);
+  $definitions = _helfi_tpr_get_content_translation_fields();
 
   foreach (['tpr_errand_service', 'tpr_service_channel'] as $entity_type) {
     foreach ($definitions as $name => $field) {
@@ -543,7 +554,28 @@ function helfi_tpr_update_8029() : void {
  * Install tpr_ontology_word_details entity type.
  */
 function helfi_tpr_update_8030() : void {
+  // Install entity type.
   $manager = \Drupal::entityDefinitionUpdateManager();
   $entity_type = \Drupal::entityTypeManager()->getDefinition('tpr_ontology_word_details');
   $manager->installEntityType($entity_type);
+
+  // Enable translation support.
+  $type = 'tpr_ontology_word_details';
+  $config_storage = \Drupal::service('config.storage');
+  $config_factory = \Drupal::configFactory();
+  $uuid_service = \Drupal::service('uuid');
+
+  $config_path = drupal_get_path('module', 'helfi_tpr') . '/config/install';
+  $source = new FileStorage($config_path);
+  $config_name = sprintf('language.content_settings.%s.%s', $type, $type);
+  $config_storage->write($config_name, $source->read($config_name));
+  $config_factory->getEditable($config_name)->set('uuid', $uuid_service->generate())->save();
+
+  // Install content translation fields.
+  $definitions = _helfi_tpr_get_content_translation_fields();
+
+  foreach ($definitions as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, $type, 'helfi_tpr', $field);
+  }
 }

--- a/helfi_tpr.links.menu.yml
+++ b/helfi_tpr.links.menu.yml
@@ -45,3 +45,15 @@ tpr_service_channel.settings:
   description: Configure TPR service channel entity type
   route_name:  tpr_service_channel.settings
   parent: system.admin_structure
+
+tpr_ontology_word_details.settings:
+  title: TPR - Ontology word details settings
+  description: Configure TPR Ontology word details entity type
+  route_name:  tpr_ontology_word_details.settings
+  parent: system.admin_structure
+
+entity.tpr_ontology_word_details.collection:
+  title: TPR - Ontology word details entities
+  description: List of TPR - Ontology word details entities
+  route_name: entity.tpr_ontology_word_details.collection
+  parent: helfi_api_base.integrations

--- a/helfi_tpr.links.task.yml
+++ b/helfi_tpr.links.task.yml
@@ -61,3 +61,14 @@ tpr_service_channel.content_list:
   route_name: entity.tpr_service_channel.collection
   base_route: helfi_api_base.integrations
   weight: 10
+
+tpr_ontology_word_details.settings:
+  title: Settings
+  route_name: tpr_ontology_word_details.settings
+  base_route: tpr_ontology_word_details.settings
+
+tpr_ontology_word_details.content_list:
+  title: TPR - Ontology word details
+  route_name: entity.tpr_ontology_word_details.collection
+  base_route: helfi_api_base.integrations
+  weight: 10

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -18,7 +18,7 @@ function helfi_tpr_theme() {
     'tpr_accessibility_sentences' => [
       'variables' => ['name' => NULL, 'items' => []],
     ],
-    'tpr-school-details' => [
+    'tpr_school_details' => [
       'variables' => ['clarification' => NULL, 'schoolyear' => NULL],
       'template' => 'tpr-school-details',
     ],
@@ -222,14 +222,14 @@ function template_preprocess_tpr_ontology_word_details(array &$variables) {
  */
 function helfi_tpr_views_data_alter(array &$data) {
   $data['tpr_unit']['emphasis_filter'] = [
+    'title' => t('Emphasis filter'),
+    'filter' => [
         'title' => t('Emphasis filter'),
-        'filter' => [
-            'title' => t('Emphasis filter'),
-            'help' => 'Filters units by emphasis.',
-            'field' => 'nid',
-            'id' => 'emphasis_filter',
-        ]
-    ];
+        'help' => 'Filters units by emphasis.',
+        'field' => 'nid',
+        'id' => 'emphasis_filter',
+    ]
+  ];
 
   $data['tpr_unit']['educational_mission_filter'] = [
     'title' => t('Educational mission'),

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -15,6 +15,10 @@ function helfi_tpr_theme() {
     'tpr_accessibility_sentences' => [
       'variables' => ['name' => NULL, 'items' => []],
     ],
+    'tpr-school-details' => [
+      'variables' => ['clarification' => NULL, 'schoolyear' => NULL],
+      'template' => 'tpr-school-details',
+    ],
     'tpr_unit' => [
       'render element' => 'elements',
       'template' => 'tpr-unit',
@@ -36,6 +40,13 @@ function helfi_tpr_theme() {
     'tpr_errand_service' => [
       'render element' => 'elements',
       'template' => 'tpr-errand-service'
+    ],
+    'tpr_ontology_word_details' => [
+      'render element' => 'elements',
+      'template' => 'tpr-ontology-word-details',
+    ],
+    'tpr_ontology_word_details_form' => [
+      'render element' => 'form',
     ],
   ];
 }
@@ -121,9 +132,9 @@ function template_preprocess_tpr_unit(array &$variables) {
 }
 
 /**
- * Prepares variables for tpr_unit templates.
+ * Prepares variables for tpr_service templates.
  *
- * Default template: tpr-unit.html.twig.
+ * Default template: tpr-service.html.twig.
  *
  * @param array $variables
  *   An associative array containing:
@@ -181,4 +192,23 @@ function template_preprocess_tpr_errand_service(array &$variables) {
     $variables['entity'] = $variables['elements']['#tpr_errand_service'];
     //$variables['content']['description_summary'] = $variables['elements']['#tpr_service_channel']->get('description')->summary;
   }
+}
+
+/**
+ * Prepares variables for tpr_ontology_word_details templates.
+ *
+ * Default template: tpr-ontology-word-details.html.twig.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - elements: An array of elements to display in view mode.
+ */
+function template_preprocess_tpr_ontology_word_details(array &$variables) {
+  $variables['view_mode'] = $variables['elements']['#view_mode'];
+  // Helpful $content variable for templates.
+  foreach (Element::children($variables['elements']) as $key) {
+    $variables['content'][$key] = $variables['elements'][$key];
+  }
+  if (isset($variables['elements']['#tpr_ontology_word_details'])) {
+    $variables['entity'] = $variables['elements']['#tpr_ontology_word_details'];}
 }

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -212,3 +212,31 @@ function template_preprocess_tpr_ontology_word_details(array &$variables) {
   if (isset($variables['elements']['#tpr_ontology_word_details'])) {
     $variables['entity'] = $variables['elements']['#tpr_ontology_word_details'];}
 }
+
+/**
+ * Implements hook_views_data_alter().
+ *
+ * @param array $data
+ *   An array of all information about Views tables and fields.
+ */
+function helfi_tpr_views_data_alter(array &$data) {
+  $data['tpr_unit']['emphasis_filter'] = [
+        'title' => t('Emphasis filter'),
+        'filter' => [
+            'title' => t('Emphasis filter'),
+            'help' => 'Filters units by emphasis.',
+            'field' => 'nid',
+            'id' => 'emphasis_filter',
+        ]
+    ];
+
+  $data['tpr_unit']['educational_mission_filter'] = [
+    'title' => t('Educational mission'),
+    'filter' => [
+      'title' => t('Educational mission'),
+      'help' => 'Filters units by educational mission.',
+      'field' => 'nid',
+      'id' => 'educational_mission_filter',
+    ]
+  ];
+}

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -224,10 +224,10 @@ function helfi_tpr_views_data_alter(array &$data) {
   $data['tpr_unit']['emphasis_filter'] = [
     'title' => t('Emphasis filter'),
     'filter' => [
-        'title' => t('Emphasis filter'),
-        'help' => 'Filters units by emphasis.',
-        'field' => 'nid',
-        'id' => 'emphasis_filter',
+      'title' => t('Emphasis filter'),
+      'help' => 'Filters units by emphasis.',
+      'field' => 'nid',
+      'id' => 'emphasis_filter',
     ]
   ];
 

--- a/migrations/tpr_ontology_word_details.yml
+++ b/migrations/tpr_ontology_word_details.yml
@@ -12,6 +12,8 @@ source:
   plugin: tpr_ontology_word_details
   translatable_fields:
     - name
+  translatable_details_fields:
+    - clarification
   track_changes: true
   url: 'https://www.hel.fi/palvelukarttaws/rest/v4/ontologyword/'
   details_url: 'https://www.hel.fi/palvelukarttaws/rest/v4/ontologyword_details/'
@@ -24,7 +26,7 @@ process:
     plugin: sub_process
     source: details
     process:
-      clarification: clarification_fi
+      clarification: clarification
       schoolyear: schoolyear
 destination:
   plugin: tpr_ontology_word_details

--- a/migrations/tpr_ontology_word_details.yml
+++ b/migrations/tpr_ontology_word_details.yml
@@ -28,6 +28,10 @@ process:
     process:
       clarification: clarification
       schoolyear: schoolyear
+  # Automatically publish ontology word details if the related unit is also published.
+  content_translation_status:
+    plugin: publish_by_unit
+    source: unit_id
 destination:
   plugin: tpr_ontology_word_details
 migration_dependencies: {  }

--- a/migrations/tpr_ontology_word_details.yml
+++ b/migrations/tpr_ontology_word_details.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - helfi_tpr
+id: tpr_ontology_word_details
+migration_tags:
+  - tpr
+label: 'TPR Ontology word details'
+source:
+  plugin: tpr_ontology_word_details
+  translatable_fields:
+    - name
+  track_changes: true
+  url: 'https://www.hel.fi/palvelukarttaws/rest/v4/ontologyword/'
+  details_url: 'https://www.hel.fi/palvelukarttaws/rest/v4/ontologyword_details/'
+process:
+  id: id
+  name: name
+  unit_id: unit_id
+  ontologyword_id: ontologyword_id
+  school_details:
+    plugin: sub_process
+    source: details
+    process:
+      clarification: clarification_fi
+      schoolyear: schoolyear
+destination:
+  plugin: tpr_ontology_word_details
+migration_dependencies: {  }

--- a/src/Entity/Form/ContentEntityForm.php
+++ b/src/Entity/Form/ContentEntityForm.php
@@ -129,7 +129,7 @@ class ContentEntityForm extends CoreContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $entity_type = $this->entity->getEntityTypeId();
 
-    if ($entity_type == 'tpr_unit' || $entity_type == 'tpr_service') {
+    if ($entity_type == 'tpr_unit' || $entity_type == 'tpr_service' || $entity_type == 'tpr_ontology_word_details') {
       parent::save($form, $form_state);
 
       $this->messenger()->addStatus($this->t('%title saved.', ['%title' => $this->entity->label()]));

--- a/src/Entity/Form/ContentEntityForm.php
+++ b/src/Entity/Form/ContentEntityForm.php
@@ -129,15 +129,13 @@ class ContentEntityForm extends CoreContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $entity_type = $this->entity->getEntityTypeId();
 
-    if ($entity_type == 'tpr_unit' || $entity_type == 'tpr_service' || $entity_type == 'tpr_ontology_word_details') {
-      parent::save($form, $form_state);
+    parent::save($form, $form_state);
 
-      $this->messenger()->addStatus($this->t('%title saved.', ['%title' => $this->entity->label()]));
+    $this->messenger()->addStatus($this->t('%title saved.', ['%title' => $this->entity->label()]));
 
-      $form_state->setRedirect('entity.' . $entity_type . '.canonical', [
-        $entity_type => $this->entity->id(),
-      ]);
-    }
+    $form_state->setRedirect('entity.' . $entity_type . '.canonical', [
+      $entity_type => $this->entity->id(),
+    ]);
   }
 
 }

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -78,8 +78,17 @@ class OntologyWordDetails extends TprEntityBase {
     return 'tpr_ontology_word_details';
   }
 
+  /**
+   * Loads one or more entities by ontology word ID.
+   *
+   * @param int $word_id
+   *   Ontology word ID.
+   *
+   * @return array
+   *   OntologyWordDetails entities.
+   */
   public static function loadMultipleByWordId(int $word_id): array {
-    $ids = \Drupal::entityQuery('tpr_ontology_word_details')->condition('ontologyword_id',$word_id)->execute();
+    $ids = \Drupal::entityQuery('tpr_ontology_word_details')->condition('ontologyword_id', $word_id)->execute();
     return OntologyWordDetails::loadMultiple($ids);
   }
 
@@ -155,18 +164,19 @@ class OntologyWordDetails extends TprEntityBase {
   /**
    * Gets details filtered by another details using a given field.
    *
-   * @param $fieldName
+   * @param string $fieldName
    *   Name of the entity's field which is used to get the details.
-   * @param $detail
+   * @param string $detail
    *   Name of the details that are returned.
-   * @param $filterName
+   * @param string $filterName
    *   Name of the details that are used to filter the returned details.
-   * @param $filterValue
+   * @param string $filterValue
    *   The filter value that must be matched.
    *
    * @return string[]|null
+   *   Array containing the details.
    */
-  public function getDetailByAnother($fieldName, $detail, $filterName, $filterValue): ?array {
+  public function getDetailByAnother(string $fieldName, string $detail, string $filterName, string $filterValue): ?array {
     $data = [];
     if (!$this->get($fieldName)->isEmpty()) {
       foreach ($this->get($fieldName)->getValue() as $item) {
@@ -177,4 +187,5 @@ class OntologyWordDetails extends TprEntityBase {
     }
     return $data ?? NULL;
   }
+
 }

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -106,6 +106,7 @@ class OntologyWordDetails extends TprEntityBase {
 
     $fields['school_details'] = BaseFieldDefinition::create('tpr_school_details')
       ->setLabel(new TranslatableMarkup('School details'))
+      ->setRevisionable(FALSE)
       ->setTranslatable(TRUE)
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE)

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -88,7 +88,10 @@ class OntologyWordDetails extends TprEntityBase {
    *   OntologyWordDetails entities.
    */
   public static function loadMultipleByWordId(int $word_id): array {
-    $ids = \Drupal::entityQuery('tpr_ontology_word_details')->condition('ontologyword_id', $word_id)->execute();
+    $ids = \Drupal::entityQuery('tpr_ontology_word_details')
+      ->condition('content_translation_status', 1)
+      ->condition('ontologyword_id', $word_id)
+      ->execute();
     return OntologyWordDetails::loadMultiple($ids);
   }
 

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -4,10 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Entity;
 
-use Drupal\content_translation\ContentTranslationHandler;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
@@ -116,51 +114,6 @@ class OntologyWordDetails extends TprEntityBase {
       ->setDisplayOptions('form', [
         'type' => 'readonly_field_widget',
       ]);
-
-    $fields['content_translation_source'] = BaseFieldDefinition::create('language')
-      ->setLabel(t('Translation source'))
-      ->setDescription(t('The source language from which this translation was created.'))
-      ->setDefaultValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
-      ->setInitialValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
-      ->setRevisionable(TRUE)
-      ->setTranslatable(TRUE);
-
-    $fields['content_translation_outdated'] = BaseFieldDefinition::create('boolean')
-      ->setLabel(t('Translation outdated'))
-      ->setDescription(t('A boolean indicating whether this translation needs to be updated.'))
-      ->setDefaultValue(FALSE)
-      ->setInitialValue(FALSE)
-      ->setRevisionable(TRUE)
-      ->setTranslatable(TRUE);
-
-    $fields['content_translation_uid'] = BaseFieldDefinition::create('entity_reference')
-      ->setLabel(t('Translation author'))
-      ->setDescription(t('The author of this translation.'))
-      ->setSetting('target_type', 'user')
-      ->setSetting('handler', 'default')
-      ->setRevisionable(TRUE)
-      ->setDefaultValueCallback(ContentTranslationHandler::class . '::getDefaultOwnerId')
-      ->setTranslatable(TRUE);
-
-    $fields['content_translation_status'] = BaseFieldDefinition::create('boolean')
-      ->setLabel(t('Translation status'))
-      ->setDescription(t('A boolean indicating whether the translation is visible to non-translators.'))
-      ->setDefaultValue(TRUE)
-      ->setInitialValue(TRUE)
-      ->setRevisionable(TRUE)
-      ->setTranslatable(TRUE);
-
-    $fields['content_translation_created'] = BaseFieldDefinition::create('created')
-      ->setLabel(t('Translation created time'))
-      ->setDescription(t('The Unix timestamp when the translation was created.'))
-      ->setRevisionable(TRUE)
-      ->setTranslatable(TRUE);
-
-    $fields['content_translation_changed'] = BaseFieldDefinition::create('changed')
-      ->setLabel(t('Translation changed time'))
-      ->setDescription(t('The Unix timestamp when the translation was most recently saved.'))
-      ->setRevisionable(TRUE)
-      ->setTranslatable(TRUE);
 
     return $fields;
   }

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Entity;
+
+use Drupal\content_translation\ContentTranslationHandler;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines the tpr_ontology_word_details entity class.
+ *
+ * @ContentEntityType(
+ *   id = "tpr_ontology_word_details",
+ *   label = @Translation("TPR - Ontology word details"),
+ *   label_collection = @Translation("TPR - Ontology word details"),
+ *   handlers = {
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
+ *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "access" = "Drupal\entity\EntityAccessControlHandler",
+ *     "permission_provider" = "Drupal\entity\EntityPermissionProvider",
+ *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",
+ *     "form" = {
+ *       "default" = "Drupal\helfi_tpr\Entity\Form\ContentEntityForm",
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\helfi_api_base\Entity\Routing\EntityRouteProvider",
+ *       "revision" = "\Drupal\helfi_api_base\Entity\Routing\RevisionRouteProvider",
+ *     },
+ *     "local_action_provider" = {
+ *       "collection" = "\Drupal\entity\Menu\EntityCollectionLocalActionProvider",
+ *     },
+ *     "local_task_provider" = {
+ *       "default" = "\Drupal\entity\Menu\DefaultEntityLocalTaskProvider",
+ *     },
+ *   },
+ *   base_table = "tpr_ontology_word_details",
+ *   data_table = "tpr_ontology_word_details_field_data",
+ *   revision_table = "tpr_ontology_word_details_revision",
+ *   revision_data_table = "tpr_ontology_word_details_field_revision",
+ *   show_revision_ui = TRUE,
+ *   revisionable = TRUE,
+ *   translatable = TRUE,
+ *   admin_permission = "administer tpr_ontology_word_details",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "revision" = "revision_id",
+ *     "langcode" = "langcode",
+ *     "label" = "name",
+ *     "uuid" = "uuid",
+ *     "published" = "content_translation_status",
+ *     "owner" = "content_translation_uid",
+ *   },
+ *   revision_metadata_keys = {
+ *     "revision_created" = "revision_timestamp",
+ *     "revision_user" = "revision_user",
+ *     "revision_log_message" = "revision_log"
+ *   },
+ *   links = {
+ *     "canonical" = "/tpr-ontology-word-details/{tpr_ontology_word_details}",
+ *     "edit-form" = "/admin/content/integrations/tpr-ontology-word-details/{tpr_ontology_word_details}/edit",
+ *     "collection" = "/admin/content/integrations/tpr-ontology-word-details",
+ *     "version-history" = "/admin/content/integrations/tpr-ontology-word-details/{tpr_ontology_word_details}/revisions",
+ *   },
+ *   field_ui_base_route = "tpr_ontology_word_details.settings"
+ * )
+ */
+class OntologyWordDetails extends TprEntityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getMigration(): ?string {
+    return 'tpr_ontology_word_details';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['unit_id'] = static::createStringField('Unit ID')
+      ->setTranslatable(FALSE);
+
+    $fields['ontologyword_id'] = static::createStringField('Ontology word ID')
+      ->setTranslatable(FALSE);
+
+    $fields['school_details'] = BaseFieldDefinition::create('tpr_school_details')
+      ->setLabel(new TranslatableMarkup('School details'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ]);
+
+    $fields['content_translation_source'] = BaseFieldDefinition::create('language')
+      ->setLabel(t('Translation source'))
+      ->setDescription(t('The source language from which this translation was created.'))
+      ->setDefaultValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
+      ->setInitialValue(LanguageInterface::LANGCODE_NOT_SPECIFIED)
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    $fields['content_translation_outdated'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Translation outdated'))
+      ->setDescription(t('A boolean indicating whether this translation needs to be updated.'))
+      ->setDefaultValue(FALSE)
+      ->setInitialValue(FALSE)
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    $fields['content_translation_uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Translation author'))
+      ->setDescription(t('The author of this translation.'))
+      ->setSetting('target_type', 'user')
+      ->setSetting('handler', 'default')
+      ->setRevisionable(TRUE)
+      ->setDefaultValueCallback(ContentTranslationHandler::class . '::getDefaultOwnerId')
+      ->setTranslatable(TRUE);
+
+    $fields['content_translation_status'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Translation status'))
+      ->setDescription(t('A boolean indicating whether the translation is visible to non-translators.'))
+      ->setDefaultValue(TRUE)
+      ->setInitialValue(TRUE)
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    $fields['content_translation_created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Translation created time'))
+      ->setDescription(t('The Unix timestamp when the translation was created.'))
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    $fields['content_translation_changed'] = BaseFieldDefinition::create('changed')
+      ->setLabel(t('Translation changed time'))
+      ->setDescription(t('The Unix timestamp when the translation was most recently saved.'))
+      ->setRevisionable(TRUE)
+      ->setTranslatable(TRUE);
+
+    return $fields;
+  }
+
+}

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -78,6 +78,11 @@ class OntologyWordDetails extends TprEntityBase {
     return 'tpr_ontology_word_details';
   }
 
+  public static function loadMultipleByWordId(int $word_id): array {
+    $ids = \Drupal::entityQuery('tpr_ontology_word_details')->condition('ontologyword_id',$word_id)->execute();
+    return OntologyWordDetails::loadMultiple($ids);
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -147,4 +152,29 @@ class OntologyWordDetails extends TprEntityBase {
     return $fields;
   }
 
+  /**
+   * Gets details filtered by another details using a given field.
+   *
+   * @param $fieldName
+   *   Name of the entity's field which is used to get the details.
+   * @param $detail
+   *   Name of the details that are returned.
+   * @param $filterName
+   *   Name of the details that are used to filter the returned details.
+   * @param $filterValue
+   *   The filter value that must be matched.
+   *
+   * @return string[]|null
+   */
+  public function getDetailByAnother($fieldName, $detail, $filterName, $filterValue): ?array {
+    $data = [];
+    if (!$this->get($fieldName)->isEmpty()) {
+      foreach ($this->get($fieldName)->getValue() as $item) {
+        if ($item[$filterName] = $filterValue) {
+          $data[$item[$detail]] = $item[$detail];
+        }
+      }
+    }
+    return $data ?? NULL;
+  }
 }

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -176,14 +176,16 @@ class OntologyWordDetails extends TprEntityBase {
    *   Name of the details that are used to filter the returned details.
    * @param string $filterValue
    *   The filter value that must be matched.
+   * @param string $langcode
+   *   The langcode.
    *
    * @return string[]|null
    *   Array containing the details.
    */
-  public function getDetailByAnother(string $fieldName, string $detail, string $filterName, string $filterValue): ?array {
+  public function getDetailByAnother(string $fieldName, string $detail, string $filterName, string $filterValue, string $langcode): ?array {
     $data = [];
-    if (!$this->get($fieldName)->isEmpty()) {
-      foreach ($this->get($fieldName)->getValue() as $item) {
+    if (!$this->getTranslation($langcode)->get($fieldName)->isEmpty()) {
+      foreach ($this->getTranslation($langcode)->get($fieldName)->getValue() as $item) {
         if ($item[$filterName] = $filterValue) {
           $data[$item[$detail]] = $item[$detail];
         }

--- a/src/Plugin/Field/FieldFormatter/SchoolDetailsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SchoolDetailsFormatter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\Field\FieldFormatter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementation of the 'School details' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "tpr_school_details",
+ *   label = @Translation("School details"),
+ *   field_types = {
+ *     "tpr_school_details"
+ *   }
+ * )
+ */
+final class SchoolDetailsFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) : array {
+    /** @var \Drupal\helfi_tpr\Plugin\Field\FieldType\AccessibilitySentenceItem[] $items */
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = [
+        '#theme' => 'tpr-school-details',
+        '#clarification' => Html::escape($item->get('clarification')->getValue()),
+        '#schoolyear' => Html::escape($item->get('schoolyear')->getValue()),
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/SchoolDetailsFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SchoolDetailsFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Plugin\Field\FieldFormatter;
 
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 
@@ -25,14 +24,14 @@ final class SchoolDetailsFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public function viewElements(FieldItemListInterface $items, $langcode) : array {
-    /** @var \Drupal\helfi_tpr\Plugin\Field\FieldType\AccessibilitySentenceItem[] $items */
+    /** @var \Drupal\helfi_tpr\Plugin\Field\FieldType\SchoolDetailsItem[] $items */
     $elements = [];
 
     foreach ($items as $delta => $item) {
       $elements[$delta] = [
-        '#theme' => 'tpr-school-details',
-        '#clarification' => Html::escape($item->get('clarification')->getValue()),
-        '#schoolyear' => Html::escape($item->get('schoolyear')->getValue()),
+        '#theme' => 'tpr_school_details',
+        '#clarification' => $item->get('clarification')->getValue(),
+        '#schoolyear' => $item->get('schoolyear')->getValue(),
       ];
     }
 

--- a/src/Plugin/Field/FieldType/SchoolDetailsItem.php
+++ b/src/Plugin/Field/FieldType/SchoolDetailsItem.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\Field\FieldType;
+
+use Drupal\Component\Utility\Random;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines the 'tpr_school_details' field type.
+ *
+ * @FieldType(
+ *   id = "tpr_school_details",
+ *   label = @Translation("School details"),
+ *   no_ui = TRUE,
+ *   default_formatter = "tpr_school_details"
+ * )
+ */
+class SchoolDetailsItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() : bool {
+    $value = $this->get('clarification')->getValue();
+    return $value === NULL || $value === '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) : array {
+    $properties['clarification'] = DataDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Clarification'))
+      ->setRequired(TRUE);
+    $properties['schoolyear'] = DataDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('Schoolyear'))
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) : array {
+    $columns = [
+      'clarification' => [
+        'type' => 'text',
+        'size' => 'big',
+      ],
+      'schoolyear' => [
+        'type' => 'varchar',
+        'not null' => FALSE,
+        'length' => 255,
+      ],
+    ];
+
+    return ['columns' => $columns];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function generateSampleValue(FieldDefinitionInterface $field_definition) : array {
+    $random = new Random();
+    foreach (['clarification', 'schoolyear'] as $key) {
+      $values[$key] = $random->word(mt_rand(1, 50));
+    }
+    return $values;
+  }
+
+}

--- a/src/Plugin/migrate/destination/OntologyWordDetails.php
+++ b/src/Plugin/migrate/destination/OntologyWordDetails.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\destination;
+
+/**
+ * Provides a destination plugin for Tpr entities.
+ *
+ * @MigrateDestination(
+ *   id = "tpr_ontology_word_details",
+ * )
+ */
+final class OntologyWordDetails extends TprDestinationBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static function getEntityTypeId($plugin_id) {
+    return 'tpr_ontology_word_details';
+  }
+
+}

--- a/src/Plugin/migrate/process/PublishByUnit.php
+++ b/src/Plugin/migrate/process/PublishByUnit.php
@@ -29,7 +29,7 @@ class PublishByUnit extends ProcessPluginBase {
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
     $unit = Unit::load($value);
-    if (!empty($unit) && $unit->get('content_translation_status')->getString() === '1') {
+    if (!empty($unit) && $unit->isPublished()) {
       return '1';
     }
     return '0';

--- a/src/Plugin/migrate/process/PublishByUnit.php
+++ b/src/Plugin/migrate/process/PublishByUnit.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\process;
+
+use Drupal\helfi_tpr\Entity\Unit;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Check unit's published status by ID and return it.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "publish_by_unit"
+ * )
+ *
+ * @code
+ * content_translation_status:
+ *   plugin: publish_by_unit
+ *   source: unit_id
+ * @endcode
+ *
+ */
+class PublishByUnit extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $unit = Unit::load($value);
+    if (!empty($unit) && $unit->get('content_translation_status')->getString() === '1') {
+      return '1';
+    }
+    return '0';
+  }
+
+}

--- a/src/Plugin/migrate/process/PublishByUnit.php
+++ b/src/Plugin/migrate/process/PublishByUnit.php
@@ -21,7 +21,6 @@ use Drupal\migrate\Row;
  *   plugin: publish_by_unit
  *   source: unit_id
  * @endcode
- *
  */
 class PublishByUnit extends ProcessPluginBase {
 

--- a/src/Plugin/migrate/source/OntologyWordDetails.php
+++ b/src/Plugin/migrate/source/OntologyWordDetails.php
@@ -132,6 +132,17 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
     }
   }
 
+  /**
+   * Combine the two content sources.
+   *
+   * @param array $content
+   *   The source JSON content.
+   * @param array $detailedContent
+   *   The source JSON content.
+   *
+   * @return array
+   *   The new source content.
+   */
   private function combineWithDetails(array $content, array $detailedContent): array {
     $content = $this->removeNonExpandableContent($content);
     $detailedContent = $this->removeDetaillessContent($detailedContent);
@@ -150,7 +161,7 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
               'name_fi' => $contentItem['ontologyword_fi'] . ' – ' . $detailedItem['unit_id'],
               'name_sv' => $contentItem['ontologyword_sv'] . ' – ' . $detailedItem['unit_id'],
               'name_en' => $contentItem['ontologyword_en'] . ' – ' . $detailedItem['unit_id'],
-              'details' => []
+              'details' => [],
             ];
           }
 
@@ -162,8 +173,10 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
     return $combined;
   }
 
-  /*
-   * @todo: Remove this later?
+  /**
+   * Removes content that is not expandable in the high school context.
+   *
+   * @todo Remove this later?
    */
   private function removeNonExpandableContent(array $content): array {
     foreach ($content as $key => $item) {
@@ -174,8 +187,10 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
     return $content;
   }
 
-  /*
-   * @todo: Remove this later?
+  /**
+   * Removes details content that does not have relevant data.
+   *
+   * @todo Remove this later?
    */
   private function removeDetaillessContent(array $content): array {
     foreach ($content as $key => $item) {

--- a/src/Plugin/migrate/source/OntologyWordDetails.php
+++ b/src/Plugin/migrate/source/OntologyWordDetails.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\source;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\helfi_api_base\Plugin\migrate\source\HttpSourcePluginBase;
+
+/**
+ * Source plugin for retrieving data from Tpr.
+ *
+ * @MigrateSource(
+ *   id = "tpr_ontology_word_details"
+ * )
+ */
+class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected bool $useRequestCache = FALSE;
+
+  /**
+   * The total count.
+   *
+   * @var int
+   */
+  protected int $count = 0;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString() : string {
+    return 'OntologyWordDetails';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() : array {
+    return [
+      'ontologyword_id' => [
+        'type' => 'string',
+      ],
+      'unit_id' => [
+        'type' => 'string',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() : array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count($refresh = FALSE) : int {
+    if (!$this->count) {
+      $originalContent = $this->getContent($this->configuration['url']);
+      $detailedContent = $this->getContent($this->configuration['details_url']);
+      $content = $this->combineWithDetails($originalContent, $detailedContent);
+
+      $this->count = count($content);
+    }
+    return $this->count;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initializeListIterator() : \Iterator {
+    $originalContent = $this->getContent($this->configuration['url']);
+    $detailedContent = $this->getContent($this->configuration['details_url']);
+    $content = $this->combineWithDetails($originalContent, $detailedContent);
+
+    $processed = 0;
+
+    foreach ($content as $item) {
+      $processed++;
+      // Allow number of items to be limited by using an env variable.
+      if (($this->getLimit() > 0) && $processed > $this->getLimit()) {
+        break;
+      }
+      yield from $this->normalizeMultilingualData($item);
+    }
+  }
+
+  /**
+   * Converts one multilingual object into multiple objects.
+   *
+   * @param array $data
+   *   The data from API.
+   *
+   * @return \Generator
+   *   The iterator.
+   */
+  protected function normalizeMultilingualData(array $data) : \Generator {
+    $delta = 0;
+
+    foreach (['fi', 'sv', 'en'] as $language) {
+      // Skip translations without translated names.
+      if (!isset($data[sprintf('name_%s', $language)])) {
+        continue;
+      }
+      $item = $data;
+
+      // Mark first item as default langcode.
+      if ($delta === 0) {
+        $item['default_langcode'] = TRUE;
+      }
+      $delta++;
+
+      $item['language'] = $language;
+
+      // 'Normalize' suffixed fields to have same name for every language.
+      // For example: name_fi, name_sv => name.
+      foreach ($this->configuration['translatable_fields'] ?? [] as $field) {
+        $key = sprintf('%s_%s', $field, $language);
+
+        if (!isset($data[$key])) {
+          continue;
+        }
+        $item[$field] = $data[$key];
+      }
+
+      yield $item;
+    }
+  }
+
+  private function combineWithDetails(array $content, array $detailedContent): array {
+    $content = $this->removeNonExpandableContent($content);
+    $detailedContent = $this->removeDetaillessContent($detailedContent);
+
+    $combined = [];
+    foreach ($content as $contentKey => $contentItem) {
+      foreach ($detailedContent as $detailedKey => $detailedItem) {
+        if ($contentItem['id'] === $detailedItem['ontologyword_id']) {
+          $id = $detailedItem['ontologyword_id'] . '_' . $detailedItem['unit_id'];
+
+          if (empty($combined[$id])) {
+            $combined[$id] = [
+              'id' => $id,
+              'ontologyword_id' => $detailedItem['ontologyword_id'],
+              'unit_id' => $detailedItem['unit_id'],
+              'name_fi' => $contentItem['ontologyword_fi'] . ' – ' . $detailedItem['unit_id'],
+              'name_sv' => $contentItem['ontologyword_sv'] . ' – ' . $detailedItem['unit_id'],
+              'name_en' => $contentItem['ontologyword_en'] . ' – ' . $detailedItem['unit_id'],
+              'details' => []
+            ];
+          }
+
+          $combined[$id]['details'][] = $detailedItem;
+        }
+      }
+    }
+
+    return $combined;
+  }
+
+  /*
+   * @todo: Remove this later?
+   */
+  private function removeNonExpandableContent(array $content): array {
+    foreach ($content as $key => $item) {
+      if ($item['can_add_schoolyear'] !== TRUE || $item['can_add_clarification'] !== TRUE) {
+        unset($content[$key]);
+      }
+    }
+    return $content;
+  }
+
+  /*
+   * @todo: Remove this later?
+   */
+  private function removeDetaillessContent(array $content): array {
+    foreach ($content as $key => $item) {
+      // @todo Make this more robust.
+      if (!isset($item['schoolyear']) || !(isset($item['clarification_fi']) || isset($item['clarification_sv']) || isset($item['clarification_en']))) {
+        unset($content[$key]);
+      }
+    }
+    return $content;
+  }
+
+}

--- a/src/Plugin/views/filter/EducationalMission.php
+++ b/src/Plugin/views/filter/EducationalMission.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_tpr\Plugin\views\filter;
 
 use Drupal\helfi_tpr\Entity\OntologyWordDetails;

--- a/src/Plugin/views/filter/EducationalMission.php
+++ b/src/Plugin/views/filter/EducationalMission.php
@@ -20,12 +20,13 @@ class EducationalMission extends OntologyWordDetailsBase {
     // @todo Get the current schoolyear e.g. from State API after the year
     // selection is implemented.
     $schoolyear = '2021-2022';
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     $details = [];
     $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(157);
     foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
       /** @var \Drupal\helfi_tpr\Entity\OntologyWordDetails $ontologyWordDetails */
-      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
+      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear, $langcode);
     }
 
     $options = array_merge(...$details);

--- a/src/Plugin/views/filter/EducationalMission.php
+++ b/src/Plugin/views/filter/EducationalMission.php
@@ -31,7 +31,7 @@ class EducationalMission extends OntologyWordDetailsBase {
       $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear, $langcode);
     }
 
-    $options = array_merge(...$details);
+    $options = array_map('ucfirst', array_merge(...$details));
     asort($options);
     return $options;
   }

--- a/src/Plugin/views/filter/EducationalMission.php
+++ b/src/Plugin/views/filter/EducationalMission.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\helfi_tpr\Plugin\views\filter;
+
+use Drupal\helfi_tpr\Entity\OntologyWordDetails;
+
+/**
+* Filter high school units by educational mission.
+*
+* @ingroup views_filter_handlers
+*
+* @ViewsFilter("educational_mission_filter")
+*/
+class EducationalMission extends OntologyWordDetailsBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generateOptions(): array {
+    // @todo Get the current schoolyear e.g. from State API after the year
+    // selection is implemented.
+    $schoolyear = '2021-2022';
+
+    $details = [];
+    $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(157);
+    foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
+      /** @var OntologyWordDetails $ontologyWordDetails */
+      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
+    }
+
+    $options = array_merge(...$details);
+    asort($options);
+    return $options;
+  }
+}

--- a/src/Plugin/views/filter/EducationalMission.php
+++ b/src/Plugin/views/filter/EducationalMission.php
@@ -5,12 +5,12 @@ namespace Drupal\helfi_tpr\Plugin\views\filter;
 use Drupal\helfi_tpr\Entity\OntologyWordDetails;
 
 /**
-* Filter high school units by educational mission.
-*
-* @ingroup views_filter_handlers
-*
-* @ViewsFilter("educational_mission_filter")
-*/
+ * Filter high school units by educational mission.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("educational_mission_filter")
+ */
 class EducationalMission extends OntologyWordDetailsBase {
 
   /**
@@ -24,7 +24,7 @@ class EducationalMission extends OntologyWordDetailsBase {
     $details = [];
     $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(157);
     foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
-      /** @var OntologyWordDetails $ontologyWordDetails */
+      /** @var \Drupal\helfi_tpr\Entity\OntologyWordDetails $ontologyWordDetails */
       $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
     }
 
@@ -32,4 +32,5 @@ class EducationalMission extends OntologyWordDetailsBase {
     asort($options);
     return $options;
   }
+
 }

--- a/src/Plugin/views/filter/Emphasis.php
+++ b/src/Plugin/views/filter/Emphasis.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_tpr\Plugin\views\filter;
 
 use Drupal\helfi_tpr\Entity\OntologyWordDetails;

--- a/src/Plugin/views/filter/Emphasis.php
+++ b/src/Plugin/views/filter/Emphasis.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\helfi_tpr\Plugin\views\filter;
+
+use Drupal\helfi_tpr\Entity\OntologyWordDetails;
+
+/**
+* Filter high school units by special emphasis or study programme.
+*
+* @ingroup views_filter_handlers
+*
+* @ViewsFilter("emphasis_filter")
+*/
+class Emphasis extends OntologyWordDetailsBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function generateOptions(): array {
+    // @todo Get the current schoolyear e.g. from State API after the year
+    // selection is implemented.
+    $schoolyear = '2021-2022';
+
+    $details = [];
+    $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(493);
+    foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
+      /** @var OntologyWordDetails $ontologyWordDetails */
+      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
+    }
+
+    $options = array_merge(...$details);
+    asort($options);
+    return $options;
+  }
+}

--- a/src/Plugin/views/filter/Emphasis.php
+++ b/src/Plugin/views/filter/Emphasis.php
@@ -5,12 +5,12 @@ namespace Drupal\helfi_tpr\Plugin\views\filter;
 use Drupal\helfi_tpr\Entity\OntologyWordDetails;
 
 /**
-* Filter high school units by special emphasis or study programme.
-*
-* @ingroup views_filter_handlers
-*
-* @ViewsFilter("emphasis_filter")
-*/
+ * Filter high school units by special emphasis or study programme.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("emphasis_filter")
+ */
 class Emphasis extends OntologyWordDetailsBase {
 
   /**
@@ -24,7 +24,7 @@ class Emphasis extends OntologyWordDetailsBase {
     $details = [];
     $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(493);
     foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
-      /** @var OntologyWordDetails $ontologyWordDetails */
+      /** @var \Drupal\helfi_tpr\Entity\OntologyWordDetails $ontologyWordDetails */
       $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
     }
 
@@ -32,4 +32,5 @@ class Emphasis extends OntologyWordDetailsBase {
     asort($options);
     return $options;
   }
+
 }

--- a/src/Plugin/views/filter/Emphasis.php
+++ b/src/Plugin/views/filter/Emphasis.php
@@ -31,7 +31,7 @@ class Emphasis extends OntologyWordDetailsBase {
       $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear, $langcode);
     }
 
-    $options = array_merge(...$details);
+    $options = array_map('ucfirst', array_merge(...$details));
     asort($options);
     return $options;
   }

--- a/src/Plugin/views/filter/Emphasis.php
+++ b/src/Plugin/views/filter/Emphasis.php
@@ -20,12 +20,13 @@ class Emphasis extends OntologyWordDetailsBase {
     // @todo Get the current schoolyear e.g. from State API after the year
     // selection is implemented.
     $schoolyear = '2021-2022';
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     $details = [];
     $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId(493);
     foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
       /** @var \Drupal\helfi_tpr\Entity\OntologyWordDetails $ontologyWordDetails */
-      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear);
+      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear, $langcode);
     }
 
     $options = array_merge(...$details);

--- a/src/Plugin/views/filter/OntologyWordDetailsBase.php
+++ b/src/Plugin/views/filter/OntologyWordDetailsBase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_tpr\Plugin\views\filter;
 
 use Drupal\views\Plugin\views\display\DisplayPluginBase;

--- a/src/Plugin/views/filter/OntologyWordDetailsBase.php
+++ b/src/Plugin/views/filter/OntologyWordDetailsBase.php
@@ -8,8 +8,8 @@ use Drupal\views\ViewExecutable;
 use Drupal\views\Views;
 
 /**
-* Base views filter class for ontology word details.
-*/
+ * Base views filter class for ontology word details.
+ */
 abstract class OntologyWordDetailsBase extends InOperator {
 
   /**
@@ -18,12 +18,11 @@ abstract class OntologyWordDetailsBase extends InOperator {
   public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
     parent::init($view, $display, $options);
     $this->valueTitle = t('Allowed clarifications');
-    $this->definition['options callback'] = array($this, 'generateOptions');
+    $this->definition['options callback'] = [$this, 'generateOptions'];
   }
 
   /**
-   * Add relationships to Ontology word details related tables and use them to
-   * filter the correct units.
+   * Add relationships to Ontology word details related tables.
    */
   public function query() {
     if (empty($this->value)) {
@@ -36,7 +35,7 @@ abstract class OntologyWordDetailsBase extends InOperator {
       'field' => 'unit_id',
       'left_table' => 'tpr_unit_field_data',
       'left_field' => 'id',
-      'operator' => '='
+      'operator' => '=',
     ];
     /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdFdJoin */
     $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
@@ -51,7 +50,7 @@ abstract class OntologyWordDetailsBase extends InOperator {
       'field' => 'entity_id',
       'left_table' => 'owd_fd',
       'left_field' => 'id',
-      'operator' => '='
+      'operator' => '=',
     ];
     /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdSdJoin */
     $owdSdJoin = Views::pluginManager('join')->createInstance('standard', $owdSdConfiguration);
@@ -64,6 +63,8 @@ abstract class OntologyWordDetailsBase extends InOperator {
    * Generates the options from ontology word details.
    *
    * @return string[]
+   *   Available options for the filter.
    */
   abstract public function generateOptions(): array;
+
 }

--- a/src/Plugin/views/filter/OntologyWordDetailsBase.php
+++ b/src/Plugin/views/filter/OntologyWordDetailsBase.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\helfi_tpr\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+
+/**
+* Base views filter class for ontology word details.
+*/
+abstract class OntologyWordDetailsBase extends InOperator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+    $this->valueTitle = t('Allowed clarifications');
+    $this->definition['options callback'] = array($this, 'generateOptions');
+  }
+
+  /**
+   * Add relationships to Ontology word details related tables and use them to
+   * filter the correct units.
+   */
+  public function query() {
+    if (empty($this->value)) {
+      return;
+    }
+
+    // Join with tpr_ontology_word_details_field_data table.
+    $owdFdConfiguration = [
+      'table' => 'tpr_ontology_word_details_field_data',
+      'field' => 'unit_id',
+      'left_table' => 'tpr_unit_field_data',
+      'left_field' => 'id',
+      'operator' => '='
+    ];
+    /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdFdJoin */
+    $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
+    $this->query->addRelationship('owd_fd', $owdFdJoin, 'tpr_unit_field_data');
+
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $this->query->addWhere('AND', 'owd_fd.langcode', $language);
+
+    // Join with tpr_ontology_word_details__school_details table.
+    $owdSdConfiguration = [
+      'table' => 'tpr_ontology_word_details__school_details',
+      'field' => 'entity_id',
+      'left_table' => 'owd_fd',
+      'left_field' => 'id',
+      'operator' => '='
+    ];
+    /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdSdJoin */
+    $owdSdJoin = Views::pluginManager('join')->createInstance('standard', $owdSdConfiguration);
+    $this->query->addRelationship('owd_sd', $owdSdJoin, 'owd_fd');
+
+    $this->query->addWhere('AND', 'owd_sd.school_details_clarification', $this->value);
+  }
+
+  /**
+   * Generates the options from ontology word details.
+   *
+   * @return string[]
+   */
+  abstract public function generateOptions(): array;
+}

--- a/templates/tpr-ontology-word-details-form.html.twig
+++ b/templates/tpr-ontology-word-details-form.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Two column template for the TPR Ontology word details add/edit form.
+ *
+ * This template is be used when an entity form specifies 'tpr-ontology-word-details-form'
+ * as its #theme callback.
+ */
+#}
+<div class="layout-entity-form clearfix">
+  <div class="layout-region layout-region--entity-main">
+    <div class="layout-region__content">
+      {{ form|without('advanced', 'footer', 'actions') }}
+    </div>
+  </div>
+  <div class="layout-region layout-region--entity-secondary">
+    <div class="layout-region__content">
+      {{ form.advanced }}
+    </div>
+  </div>
+  <div class="layout-region layout-region--entity-footer">
+    <div class="layout-region__content">
+      <div class="divider"></div>
+      {{ form.footer }}
+      {{ form.actions }}
+    </div>
+  </div>
+</div>

--- a/templates/tpr-ontology-word-details.html.twig
+++ b/templates/tpr-ontology-word-details.html.twig
@@ -1,0 +1,38 @@
+{#
+/**
+ * @file
+ * Template for a TPR Ontology word details entity.
+ */
+#}
+
+{%
+  set classes = [
+  'ontology-word-details',
+  view_mode ? 'ontology-word-details--' ~ view_mode|clean_class,
+]
+%}
+<article{{ attributes.addClass(classes) }}>
+
+  <div class="ontology-word-details__container container">
+    <div{{ content_attributes.addClass('ontology-word-details__header') }}>
+      <h2{{ title_attributes.addClass('ontology-word-details__title') }}>
+        {{ content.name }}
+      </h2>
+    </div>
+    {% if content.unit_id|render %}
+      <div class="ontology-word-details__unit-id">
+        {{ content.unit_id }}
+      </div>
+    {% endif %}
+    {% if content.ontologyword_id|render %}
+      <div class="ontology-word-details__ontologyword-id">
+        {{ content.ontologyword_id }}
+      </div>
+    {% endif %}
+    {% if content.school_details|render %}
+      <div class="ontology-word-details__school-details">
+        {{ content.school_details }}
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/templates/tpr-school-details.html.twig
+++ b/templates/tpr-school-details.html.twig
@@ -1,0 +1,1 @@
+ <p>{{ clarification }} ({{ schoolyear }})</p>

--- a/tests/src/Functional/ServiceRevisionTest.php
+++ b/tests/src/Functional/ServiceRevisionTest.php
@@ -48,7 +48,7 @@ class ServiceRevisionTest extends MigrationTestBase {
       $this->assertSession()->pageTextContains("Description long $language 1");
       $this->assertSession()->pageTextContains("Service $language 1");
 
-      $expected_url = Url::fromRoute('entity.tpr_service.version_history', ['tpr_service' => 1], ['query' => ['language' => $language]])->toString();
+      $expected_url = Url::fromRoute('entity.tpr_service.version_history', ['tpr_service' => 1])->toString();
       // Go to revisions tab and make sure it's visible.
       $this->getSession()->getPage()->findLink('Revisions')->click();
 
@@ -70,7 +70,7 @@ class ServiceRevisionTest extends MigrationTestBase {
       $this->assertTrue(count($count) >= 3);
     }
 
-    // Update TPR data and make sure reverting revisions doens't revert TPR
+    // Update TPR data and make sure reverting revisions doesn't revert TPR
     // fields.
     Service::load(1)
       ->getTranslation('fi')

--- a/tests/src/Functional/UnitListTest.php
+++ b/tests/src/Functional/UnitListTest.php
@@ -88,15 +88,12 @@ class UnitListTest extends ListTestBase {
       'action' => 'tpr_unit_update_action',
       // The list is sorted by changed timestamp so our updated entities
       // should be at the top of the list.
-      'tpr_unit_bulk_form[0]' => 1,
       'tpr_unit_bulk_form[1]' => 1,
     ];
     $this->submitForm($form_data, 'Apply to selected items');
 
-    $this->assertSession()->pageTextNotContains('Test 1');
     $this->assertSession()->pageTextNotContains('Test 2');
     $this->assertSession()->pageTextContains('Esteetön testireitti / Leppävaara');
-    $this->assertSession()->pageTextContains('InnoOmnia');
 
     // Make sure we can use actions to publish and unpublish content.
     $this->assertPublishAction('tpr_unit', $query);

--- a/tests/src/Functional/UnitRevisionTest.php
+++ b/tests/src/Functional/UnitRevisionTest.php
@@ -50,7 +50,7 @@ class UnitRevisionTest extends MigrationTestBase {
       // Go to revisions tab and make sure it's visible.
       $this->getSession()->getPage()->findLink('Revisions')->click();
 
-      $expected_url = Url::fromRoute('entity.tpr_unit.version_history', ['tpr_unit' => 1], ['query' => ['language' => $language]])->toString();
+      $expected_url = Url::fromRoute('entity.tpr_unit.version_history', ['tpr_unit' => 1])->toString();
       $this->assertSession()->addressEquals($expected_url);
       $this->assertSession()->statusCodeEquals(200);
 
@@ -69,7 +69,7 @@ class UnitRevisionTest extends MigrationTestBase {
       $this->assertTrue(count($count) >= 3);
     }
 
-    // Update TPR data and make sure reverting revisions doens't revert TPR
+    // Update TPR data and make sure reverting revisions doesn't revert TPR
     // fields.
     Unit::load(1)
       ->getTranslation('fi')

--- a/tests/src/Kernel/MigrationTestBase.php
+++ b/tests/src/Kernel/MigrationTestBase.php
@@ -39,6 +39,7 @@ abstract class MigrationTestBase extends ApiMigrationTestBase {
       'tpr_service',
       'tpr_errand_service',
       'tpr_service_channel',
+      'tpr_ontology_word_details',
     ];
 
     foreach ($entity_types as $type) {

--- a/tests/src/Kernel/OntologyWordDetailsTest.php
+++ b/tests/src/Kernel/OntologyWordDetailsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\helfi_tpr\Entity\OntologyWordDetails;
+
+/**
+ * Tests TPR Ontology word details entities.
+ *
+ * @group helfi_tpr
+ */
+class OntologyWordDetailsTest extends MigrationTestBase {
+
+  /**
+   * Gets the TPR Ontology word details entity.
+   *
+   * @param string $id
+   *   The id.
+   *
+   * @return \Drupal\helfi_tpr\Entity\OntologyWordDetails
+   *   The entity.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function getEntity(string $id) : OntologyWordDetails {
+    $entity = OntologyWordDetails::create([
+      'id' => $id,
+      'name' => 'TPR Ontology word details ' . $id,
+    ]);
+    $entity->save();
+
+    return $entity;
+  }
+
+  /**
+   * Tests entity deletion.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testEntityDeletion() : void {
+    $entity = $this->getEntity('1_1');
+
+    // Test that the entity is not deleted.
+    // See Drupal\helfi_tpr\Entity\TprEntityBase::delete() for more
+    // information.
+    $entity->delete();
+    $this->assertNotEquals(NULL, OntologyWordDetails::load('1_1'));
+  }
+
+}


### PR DESCRIPTION
Adds import for "ontology word details" and adds a new entity "OntologyWordDetails" for them. When these are imported, they are automatically published if the relevant Unit entity is also published.

For now, these are only used to get information high school search filtering.

**How to test:**
* Setup up Kasko development environment.
* Check out Kasko branch `UHF-2604-kasko-ontology_word_details`.
* Get the changes for this module: `composer require drupal/helfi_tpr:dev-UHF-2604-ontology_word_details`
* Run database updates: `drush updb`
* Import configs: `drush cim`
* Clear caches: `drush cr`
* Make sure you have imported tpr_units including Helsinki's upper secondary schools (you can use [this](https://www.hel.fi/helsinki/fi/kasvatus-ja-koulutus/lukiot/opiskelu/lukioiden-painotukset/) list to check what schools there are).
  * Publish those upper secondary school units (and maybe also e.g. Swedish translations)
* Make sure you have a landing page with High school search component (and maybe also a Swedish translation).
  * ...and those published schools are added to that search.
* Run: `drush migrate:import tpr_ontology_word_details`
* Now open the page containing the High school search and you should be able to filter the results using the "Select a special emphasis or study programme" and "Select a special educational mission" fields.
  * Using the list mentioned above, check that the filtering works correctly: correct emphasis and educational missions for correct schools.

Also check the relevant site specific PR: https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/37