### PR TITLE
UHF-3449: Add filter for study programme type

### DIFF
--- a/config/schema/helfi_tpr.schema.yml
+++ b/config/schema/helfi_tpr.schema.yml
@@ -33,13 +33,3 @@ field.value.tpr_connection:
     value:
       type: label
       label: Value
-
-# Schema definition for emphasis filter.
-views.filter.emphasis_filter:
-  type: views.filter.in_operator
-  label: 'Allowed clarifications'
-
-# Schema definition for educational mission filter.
-views.filter.educational_mission_filter:
-  type: views.filter.in_operator
-  label: 'Allowed clarifications'

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -567,3 +567,18 @@ function helfi_tpr_update_8030() : void {
       ->installFieldStorageDefinition($name, $type, 'helfi_tpr', $field);
   }
 }
+
+/**
+ * Re-install school_details field.
+ */
+function helfi_tpr_update_8031() : void {
+  drupal_flush_all_caches();
+  $manager = \Drupal::entityDefinitionUpdateManager();
+
+  if ($definition = $manager->getFieldStorageDefinition('school_details', 'tpr_ontology_word_details')) {
+    // Removes all field data. However, the data is fetched using
+    // tpr_ontology_word_details migration so importing it again should be easy.
+    $manager->uninstallFieldStorageDefinition($definition);
+    $manager->installFieldStorageDefinition('school_details', 'tpr_ontology_word_details', 'helfi_tpr', $definition);
+  }
+}

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -215,34 +215,6 @@ function template_preprocess_tpr_ontology_word_details(array &$variables) {
 }
 
 /**
- * Implements hook_views_data_alter().
- *
- * @param array $data
- *   An array of all information about Views tables and fields.
- */
-function helfi_tpr_views_data_alter(array &$data) {
-  $data['tpr_unit']['emphasis_filter'] = [
-    'title' => t('Emphasis filter'),
-    'filter' => [
-      'title' => t('Emphasis filter'),
-      'help' => 'Filters units by emphasis.',
-      'field' => 'nid',
-      'id' => 'emphasis_filter',
-    ]
-  ];
-
-  $data['tpr_unit']['educational_mission_filter'] = [
-    'title' => t('Educational mission'),
-    'filter' => [
-      'title' => t('Educational mission'),
-      'help' => 'Filters units by educational mission.',
-      'field' => 'nid',
-      'id' => 'educational_mission_filter',
-    ]
-  ];
-}
-
-/**
  * Implements hook_ENTITY_TYPE_access().
  */
 function helfi_tpr_tpr_unit_access(EntityInterface $entity, $operation, AccountInterface $account) {

--- a/helfi_tpr.services.yml
+++ b/helfi_tpr.services.yml
@@ -7,3 +7,5 @@ services:
     class: Drupal\helfi_tpr\Fixture\ErrandService
   migration_fixture.tpr_service_channel:
     class: Drupal\helfi_tpr\Fixture\ServiceChannel
+  migration_fixture.tpr_ontology_word_details:
+    class: Drupal\helfi_tpr\Fixture\OntologyWordDetails

--- a/modules/helfi_school_addons/config/schema/helfi_school_addons.schema.yml
+++ b/modules/helfi_school_addons/config/schema/helfi_school_addons.schema.yml
@@ -1,0 +1,14 @@
+# Schema definition for emphasis filter.
+views.filter.emphasis_filter:
+  type: views.filter.in_operator
+  label: 'Allowed clarifications'
+
+# Schema definition for educational mission filter.
+views.filter.educational_mission_filter:
+  type: views.filter.in_operator
+  label: 'Allowed clarifications'
+
+# Schema definition for study programme type filter.
+views.filter.study_programme_type_filter:
+  type: views.filter.in_operator
+  label: 'Allowed values'

--- a/modules/helfi_school_addons/helfi_school_addons.module
+++ b/modules/helfi_school_addons/helfi_school_addons.module
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Contains helfi_school_addons.
+ */
+
+/**
+ * Implements hook_views_data_alter().
+ *
+ * @param array $data
+ *   An array of all information about Views tables and fields.
+ */
+function helfi_school_addons_views_data_alter(array &$data) {
+  $data['tpr_unit']['emphasis_filter'] = [
+    'title' => t('Emphasis filter'),
+    'filter' => [
+      'title' => t('Emphasis filter'),
+      'help' => 'Filters units by emphasis.',
+      'field' => 'nid',
+      'id' => 'emphasis_filter',
+    ]
+  ];
+
+  $data['tpr_unit']['educational_mission_filter'] = [
+    'title' => t('Educational mission'),
+    'filter' => [
+      'title' => t('Educational mission'),
+      'help' => 'Filters units by educational mission.',
+      'field' => 'nid',
+      'id' => 'educational_mission_filter',
+    ]
+  ];
+
+  $data['tpr_unit']['study_programme_type_filter'] = [
+    'title' => t('Study programme type'),
+    'filter' => [
+      'title' => t('Study programme type'),
+      'help' => 'Filters units by study programme type.',
+      'field' => 'nid',
+      'id' => 'study_programme_type_filter',
+    ]
+  ];
+}

--- a/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
@@ -85,6 +85,11 @@ abstract class SchoolDetailsBase extends InOperator {
     $owdSdJoin = Views::pluginManager('join')->createInstance('standard', $owdSdConfiguration);
     $this->query->addRelationship('owd_sd', $owdSdJoin, 'owd_fd');
 
+    $schoolYear = SchoolUtility::getCurrentSchoolYear();
+    if ($schoolYear) {
+      $this->query->addWhere('AND', 'owd_sd.school_details_schoolyear', $schoolYear);
+    }
+
     $this->query->addWhere('AND', 'owd_sd.school_details_clarification', $this->value);
   }
 
@@ -100,8 +105,8 @@ abstract class SchoolDetailsBase extends InOperator {
     }
 
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    $schoolyear = SchoolUtility::getCurrentSchoolYear();
-    if ($schoolyear === NULL) {
+    $schoolYear = SchoolUtility::getCurrentSchoolYear();
+    if ($schoolYear === NULL) {
       return [];
     }
 
@@ -109,7 +114,7 @@ abstract class SchoolDetailsBase extends InOperator {
     $multipleOntologyWordDetails = OntologyWordDetails::loadMultipleByWordId($this->wordId);
     foreach ($multipleOntologyWordDetails as $ontologyWordDetails) {
       /** @var \Drupal\helfi_tpr\Entity\OntologyWordDetails $ontologyWordDetails */
-      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolyear, $langcode);
+      $details[] = $ontologyWordDetails->getDetailByAnother('school_details', 'clarification', 'schoolyear', $schoolYear, $langcode);
     }
 
     $options = array_map('ucfirst', array_merge(...$details));

--- a/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_school_addons\Plugin\views\filter;
+
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\filter\InOperator;
+use Drupal\views\ViewExecutable;
+use Drupal\views\Views;
+
+/**
+ * Filter school units by study programme type.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("study_programme_type_filter")
+ */
+class StudyProgrammeType extends InOperator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
+    $this->valueTitle = t('Allowed values');
+    $this->definition['options callback'] = [$this, 'generateOptions'];
+  }
+
+  /**
+   * Builds the views filter query.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function query() {
+    if (empty($this->value) || (isset($this->value[0]) && $this->value[0] === 'All')) {
+      return;
+    }
+
+    $valueToWordId = [
+      'general' => [
+        816,
+      ],
+      'adult' => [
+        650,
+        590,
+      ],
+    ];
+
+    if (!isset($this->value[0]) || !array_key_exists($this->value[0], $valueToWordId)) {
+      return;
+    }
+
+    // Join with tpr_ontology_word_details_field_data table.
+    $owdFdConfiguration = [
+      'table' => 'tpr_ontology_word_details_field_data',
+      'field' => 'unit_id',
+      'left_table' => 'tpr_unit_field_data',
+      'left_field' => 'id',
+      'operator' => '=',
+    ];
+    /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdFdJoin */
+    $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
+    $this->query->addRelationship('owd_fd_spt', $owdFdJoin, 'tpr_unit_field_data');
+
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $this->query->addWhere('AND', 'owd_fd_spt.langcode', $language);
+
+    $orGroup = $this->query->setWhereGroup('OR', 'OR');
+    foreach ($valueToWordId[$this->value[0]] as $wordId) {
+      $this->query->addWhere($orGroup, 'owd_fd_spt.ontologyword_id', $wordId);
+    }
+  }
+
+  /**
+   * Generates options for the filter.
+   *
+   * @return string[]
+   *   Available options for the filter.
+   */
+  protected function generateOptions(): array {
+    return [
+      'general' => t('General programme'),
+      'adult' => t('Upper secondary school for adults and a study programme'),
+    ];
+  }
+
+}

--- a/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_school_addons\Plugin\views\filter;
 
+use Drupal\helfi_school_addons\SchoolUtility;
 use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\filter\InOperator;
 use Drupal\views\ViewExecutable;
@@ -65,6 +66,23 @@ class StudyProgrammeType extends InOperator {
 
     $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $this->query->addWhere('AND', 'owd_fd_spt.langcode', $language);
+
+    // Join with tpr_ontology_word_details__school_details table.
+    $owdSdConfiguration = [
+      'table' => 'tpr_ontology_word_details__school_details',
+      'field' => 'entity_id',
+      'left_table' => 'owd_fd_spt',
+      'left_field' => 'id',
+      'operator' => '=',
+    ];
+    /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $owdSdJoin */
+    $owdSdJoin = Views::pluginManager('join')->createInstance('standard', $owdSdConfiguration);
+    $this->query->addRelationship('owd_sd_spt', $owdSdJoin, 'owd_fd_spt');
+
+    $schoolYear = SchoolUtility::getCurrentSchoolYear();
+    if ($schoolYear) {
+      $this->query->addWhere('AND', 'owd_sd_spt.school_details_schoolyear', $schoolYear);
+    }
 
     $orGroup = $this->query->setWhereGroup('OR', 'OR');
     foreach ($valueToWordId[$this->value[0]] as $wordId) {

--- a/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
@@ -80,8 +80,8 @@ class StudyProgrammeType extends InOperator {
    */
   protected function generateOptions(): array {
     return [
-      'general' => t('General programme'),
-      'adult' => t('Upper secondary school for adults and a study programme'),
+      'general' => t('The general programme or study programme'),
+      'adult' => t('The upper secondary school for adults or a study programme'),
     ];
   }
 

--- a/src/Fixture/OntologyWordDetails.php
+++ b/src/Fixture/OntologyWordDetails.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Fixture;
+
+use Drupal\helfi_api_base\Fixture\FixtureBase;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Provides fixture data for tpr_ontology_word_details migration.
+ */
+final class OntologyWordDetails extends FixtureBase {
+
+  /**
+   * Gets the mock data.
+   *
+   * @return array[]
+   *   The mock data.
+   */
+  public function getMockData() : array {
+    return [
+      [
+        'id' => 157,
+        'ontologyword_fi' => 'erityistehtävän mukaiset lukiot',
+        'ontologyword_sv' => 'gymnasier enligt specialuppgift',
+        'ontologyword_en' => 'special educational mission upper secondary schools',
+        'can_add_schoolyear' => TRUE,
+        'can_add_clarification' => TRUE,
+        'unit_ids' => [
+          6820,
+          7051,
+          15348,
+          18649,
+          19274,
+          19428,
+          19890,
+          30854,
+          30855,
+          30858,
+          30862,
+          30863,
+          30864,
+          61450,
+        ],
+        'details' => [
+          [
+            'unit_id' => 30855,
+            'ontologyword_id' => 157,
+            'schoolyear' => '2021-2022',
+            'clarification_fi' => 'kuvataide',
+            'clarification_sv' => 'bildkonst',
+            'clarification_en' => 'visual arts',
+          ],
+          [
+            'unit_id' => 30862,
+            'ontologyword_id' => 157,
+            'schoolyear' => '2021-2022',
+            'clarification_fi' => 'urheilu',
+            'clarification_sv' => 'idrott',
+            'clarification_en' => 'sports',
+          ],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMockResponses() : array {
+    $owds = $this->getMockData();
+    $responses = [
+      new Response(200, [], json_encode($owds)),
+    ];
+
+    foreach ($owds as $owd) {
+      $responses[] = new Response(200, [], json_encode($owd['details']));
+    }
+    return $responses;
+  }
+
+}

--- a/src/Plugin/Field/FieldType/SchoolDetailsItem.php
+++ b/src/Plugin/Field/FieldType/SchoolDetailsItem.php
@@ -27,8 +27,9 @@ class SchoolDetailsItem extends FieldItemBase {
    * {@inheritdoc}
    */
   public function isEmpty() : bool {
-    $value = $this->get('clarification')->getValue();
-    return $value === NULL || $value === '';
+    $clarification = $this->get('clarification')->getValue();
+    $schoolyear = $this->get('schoolyear')->getValue();
+    return ($clarification === NULL || $clarification === '') && ($schoolyear === NULL || $schoolyear === '');
   }
 
   /**
@@ -37,10 +38,10 @@ class SchoolDetailsItem extends FieldItemBase {
   public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) : array {
     $properties['clarification'] = DataDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Clarification'))
-      ->setRequired(TRUE);
+      ->setRequired(FALSE);
     $properties['schoolyear'] = DataDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Schoolyear'))
-      ->setRequired(TRUE);
+      ->setRequired(FALSE);
 
     return $properties;
   }
@@ -56,7 +57,6 @@ class SchoolDetailsItem extends FieldItemBase {
       ],
       'schoolyear' => [
         'type' => 'varchar',
-        'not null' => FALSE,
         'length' => 255,
       ],
     ];

--- a/src/Plugin/migrate/source/OntologyWordDetails.php
+++ b/src/Plugin/migrate/source/OntologyWordDetails.php
@@ -26,7 +26,18 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
    *
    * @var bool
    */
-  protected bool $limitBySchoolDetails = TRUE;
+  protected bool $includeSchoolDetails = TRUE;
+
+  /**
+   * Include source data with selected ontology IDs.
+   *
+   * @var int[]
+   */
+  protected array $includeOntologyIds = [
+    816,
+    650,
+    590,
+  ];
 
   /**
    * {@inheritdoc}
@@ -143,8 +154,15 @@ class OntologyWordDetails extends HttpSourcePluginBase implements ContainerFacto
     foreach ($content as $contentKey => $contentItem) {
       foreach ($detailedContent as $detailedKey => $detailedItem) {
         if ($contentItem['id'] === $detailedItem['ontologyword_id']) {
-          // Proceed only if detailed content has relevant data.
-          if ($this->limitBySchoolDetails ? !$this->hasSchoolDetails($detailedItem) : FALSE) {
+          // Only process pre-selected source data.
+          $process = FALSE;
+          if ($this->includeSchoolDetails ? $this->hasSchoolDetails($detailedItem) : FALSE) {
+            $process = TRUE;
+          }
+          if (!empty($this->includeOntologyIds) ? in_array($contentItem['id'], $this->includeOntologyIds) : FALSE) {
+            $process = TRUE;
+          }
+          if (!$process) {
             continue;
           }
 

--- a/tests/src/Kernel/OntologyWordDetailsMigrationTest.php
+++ b/tests/src/Kernel/OntologyWordDetailsMigrationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\helfi_tpr\Entity\OntologyWordDetails;
+
+/**
+ * Tests TPR Ontology word details migration.
+ *
+ * @group helfi_tpr
+ */
+class OntologyWordDetailsMigrationTest extends MigrationTestBase {
+
+  /**
+   * Tests ontology word details migration.
+   */
+  public function testOntologyWordDetailsMigration() : void {
+    $this->runOntologyWordDetailsMigrate();
+    $entities = OntologyWordDetails::loadMultiple();
+    $this->assertCount(2, $entities);
+
+    foreach ($this->expectedOntologyWordDetailsData() as $langcode => $expected) {
+      /** @var \Drupal\helfi_tpr\Entity\Unit $translation */
+      $translation = $entities['157_30855']->getTranslation($langcode);
+
+      $this->assertEquals($expected['id'], $translation->id());
+      $this->assertEquals($expected['name'], $translation->label());
+      $this->assertEquals($expected['ontologyword_id'], $translation->get('ontologyword_id')->value);
+      $this->assertEquals($expected['unit_id'], $translation->get('unit_id')->value);
+      $this->assertEquals(1, $translation->get('school_details')->count());
+    }
+  }
+
+  /**
+   * The data provider for ontology word details migration.
+   *
+   * @return array
+   *   The data.
+   */
+  public function expectedOntologyWordDetailsData() : array {
+    return [
+      'en' => [
+        'id' => '157_30855',
+        'name' => '30855: special educational mission upper secondary schools',
+        'ontologyword_id' => '157',
+        'unit_id' => '30855',
+      ],
+      'fi' => [
+        'id' => '157_30855',
+        'name' => '30855: erityistehtävän mukaiset lukiot',
+        'ontologyword_id' => '157',
+        'unit_id' => '30855',
+      ],
+      'sv' => [
+        'id' => '157_30855',
+        'name' => '30855: gymnasier enligt specialuppgift',
+        'ontologyword_id' => '157',
+        'unit_id' => '30855',
+      ],
+    ];
+  }
+
+}

--- a/tests/src/Traits/TprMigrateTrait.php
+++ b/tests/src/Traits/TprMigrateTrait.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\helfi_tpr\Traits;
 use Drupal\helfi_api_base\Fixture\FixtureBase;
 
 /**
- * Provides shared functionality for unit entity tests.
+ * Provides shared functionality for TPR entity tests.
  */
 trait TprMigrateTrait {
 
@@ -55,6 +55,20 @@ trait TprMigrateTrait {
     }
     $this->container->set('http_client', $this->createMockHttpClient($responses));
     $this->executeMigration('tpr_errand_service');
+  }
+
+  /**
+   * Runs the 'tpr_ontology_word_details' migration.
+   *
+   * @param array $responses
+   *   The mock responses.
+   */
+  protected function runOntologyWordDetailsMigrate(array $responses = []): void {
+    if (empty($responses)) {
+      $responses = $this->fixture('tpr_ontology_word_details')->getMockResponses();
+    }
+    $this->container->set('http_client', $this->createMockHttpClient($responses));
+    $this->executeMigration('tpr_ontology_word_details');
   }
 
 }


### PR DESCRIPTION
Adds filter for study programme type (general studies / adult education) which is used with the high school search. The `tpr_ontology_word_details` migration is modified to include relevant ontlogy word details.

**How to test:**

* Setup up Kasko development environment.
* Check out Kasko branch `UHF-3449-kasko-study-programme`.
* Get the changes for this module: `composer require drupal/helfi_tpr:dev-UHF-3449-general-or-adults-filter`.
* Get changes to translations: `composer require drupal/helfi_platform_config:dev-UHF-3449-study-programme-translations`.
* Import configs: `drush cim`.
* Run database update: `drush updb`.
* Clear caches: `drush cr`.
* Import translations:
  - `drush locale-import fi /app/public/modules/contrib/helfi_platform_config/translations/fi/strings.po`.
  - `drush locale-import sv /app/public/modules/contrib/helfi_platform_config/translations/sv/strings.po`.
* Make sure you have imported tpr_units including Helsinki's upper secondary schools (you can use [this](https://www.hel.fi/helsinki/fi/kasvatus-ja-koulutus/lukiot/opiskelu/lukioiden-painotukset/) list to check what schools there are).
* Publish those upper secondary school units (and maybe also Swedish and English translations).
* Make sure you have a landing page with High school search component (and maybe also a Swedish and English translations).
  * ...and make sure those published schools are added to that search.
* Run: `drush migrate:import tpr_ontology_word_details` (run it twice)
* Make sure the school year is set to `2021-2022` from the `/admin/config/school-settings` settings page.
* Go to the page including the high school search.
  * Make sure the filters work.
  * If you have published all Helsinki high schools:
    * When no filters are set, there should be 15 results.
    * When selecting "The general programme or study programme", there should be 12 results.
    * When selecting "The upper secondary school for adults or a study programme", there should be 2 results (Tölö gymnasium, Helsingin aikuislukio).
  * You can further limit the results by selecting also emphasis / educational mission filters.

Also check these relevant PRs:
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/45
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/238