### PR TITLE
UHF-3691: Removed canonical route from TPR service channel and errand service entities

### DIFF
--- a/helfi_tpr.links.task.yml
+++ b/helfi_tpr.links.task.yml
@@ -25,11 +25,6 @@ tpr_errand_service.settings:
   route_name: tpr_errand_service.settings
   base_route: tpr_errand_service.settings
 
-entity.tpr_errand_service.view:
-  title: View
-  route_name: entity.tpr_errand_service.canonical
-  base_route: entity.tpr_errand_service.canonical
-
 entity.tpr_errand_service.edit_form:
   title: Edit
   route_name: entity.tpr_errand_service.edit_form
@@ -45,11 +40,6 @@ tpr_service_channel.settings:
   title: Settings
   route_name: tpr_service_channel.settings
   base_route: tpr_service_channel.settings
-
-entity.tpr_service_channel.view:
-  title: View
-  route_name: entity.tpr_service_channel.canonical
-  base_route: entity.tpr_service_channel.canonical
 
 entity.tpr_service_channel.edit_form:
   title: Edit

--- a/helfi_tpr.links.task.yml
+++ b/helfi_tpr.links.task.yml
@@ -25,11 +25,6 @@ tpr_errand_service.settings:
   route_name: tpr_errand_service.settings
   base_route: tpr_errand_service.settings
 
-entity.tpr_errand_service.edit_form:
-  title: Edit
-  route_name: entity.tpr_errand_service.edit_form
-  base_route: entity.tpr_errand_service.canonical
-
 tpr_errand_service.content_list:
   title: TPR - Errand Service
   route_name: entity.tpr_errand_service.collection
@@ -40,11 +35,6 @@ tpr_service_channel.settings:
   title: Settings
   route_name: tpr_service_channel.settings
   base_route: tpr_service_channel.settings
-
-entity.tpr_service_channel.edit_form:
-  title: Edit
-  route_name: entity.tpr_service_channel.edit_form
-  base_route: entity.tpr_service_channel.canonical
 
 tpr_service_channel.content_list:
   title: TPR - Service channel

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -51,7 +51,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "revision_log_message" = "revision_log"
  *   },
  *   links = {
- *     "canonical" = "/tpr-service_channel/{tpr_service_channel}",
  *     "edit-form" = "/admin/content/integrations/tpr-service-channel/{tpr_service_channel}/edit",
  *     "collection" = "/admin/content/integrations/tpr-service-channel"
  *   },

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -22,6 +22,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
+ *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",
  *     },
@@ -29,6 +30,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *       "html" = "Drupal\helfi_api_base\Entity\Routing\EntityRouteProvider",
  *     },
  *   },
+ *   content_translation_ui_skip = TRUE,
  *   base_table = "tpr_service_channel",
  *   data_table = "tpr_service_channel_field_data",
  *   revision_table = "tpr_service_channel_revision",

--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -49,7 +49,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "revision_log_message" = "revision_log"
  *   },
  *   links = {
- *     "canonical" = "/tpr-errand-service/{tpr_errand_service}",
  *     "edit-form" = "/admin/content/integrations/tpr-errand-service/{tpr_errand_service}/edit",
  *     "collection" = "/admin/content/integrations/tpr-errand-service"
  *   },

--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -20,6 +20,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
+ *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",
  *     },
@@ -27,6 +28,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *       "html" = "Drupal\helfi_api_base\Entity\Routing\EntityRouteProvider",
  *     },
  *   },
+ *   content_translation_ui_skip = TRUE,
  *   base_table = "tpr_errand_service",
  *   data_table = "tpr_errand_service_field_data",
  *   revision_table = "tpr_errand_service_revision",


### PR DESCRIPTION
To test this:

- `composer require drupal/helfi_tpr:dev-UHF-3691` 
- `drush cr`

What to test:

- Errand service and service channel canonical URLs are not accessible anymore (404)
- You can still edit them through edit form
- Both entities are still shown via entity reference field display