### PR TITLE
UHF-4643: Custom views filter for unpublished TPR entities

### DIFF
--- a/helfi_tpr.views_execution.inc
+++ b/helfi_tpr.views_execution.inc
@@ -5,6 +5,7 @@
  * Views alter for helfi_tpr.
  */
 
+use Drupal\Core\Entity\EntityType;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
@@ -33,4 +34,25 @@ function helfi_tpr_views_pre_execute(ViewExecutable $view) {
       END COLLATE utf8mb4_swedish_ci', 'name_sort'
     );
   }
+}
+
+/**
+ * Implements hook_views_query_substitutions().
+ */
+function helfi_tpr_views_query_substitutions(ViewExecutable $view) {
+
+  // Get permission name dynamically.
+  $base_entity = $view->getBaseEntityType();
+  if ($base_entity instanceof EntityType) {
+    $entity_permission = 'view unpublished ' . $base_entity->id();
+  }
+  // Default to no access if entity type can't be loaded.
+  else {
+    return ['***VIEW_UNPUBLISHED_TPR_ENTITIES***' => 0];
+  }
+
+  $account = \Drupal::currentUser();
+  return [
+    '***VIEW_UNPUBLISHED_TPR_ENTITIES***' => intval($account->hasPermission($entity_permission)),
+  ];
 }

--- a/src/Entity/Channel.php
+++ b/src/Entity/Channel.php
@@ -20,7 +20,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\helfi_tpr\TprViewsData",
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
  *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",
  *     "form" = {

--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -18,7 +18,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\helfi_tpr\TprViewsData",
  *     "access" = "Drupal\helfi_api_base\Entity\Access\RemoteEntityAccess",
  *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",
  *     "form" = {

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -18,7 +18,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\helfi_tpr\TprViewsData",
  *     "access" = "Drupal\entity\EntityAccessControlHandler",
  *     "permission_provider" = "Drupal\entity\EntityPermissionProvider",
  *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -18,7 +18,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\helfi_tpr\TprViewsData",
  *     "access" = "Drupal\entity\EntityAccessControlHandler",
  *     "permission_provider" = "Drupal\entity\EntityPermissionProvider",
  *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -21,7 +21,7 @@ use Webmozart\Assert\Assert;
  *   handlers = {
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\helfi_tpr\Entity\Listing\ListBuilder",
- *     "views_data" = "Drupal\views\EntityViewsData",
+ *     "views_data" = "Drupal\helfi_tpr\TprViewsData",
  *     "access" = "Drupal\entity\EntityAccessControlHandler",
  *     "permission_provider" = "Drupal\entity\EntityPermissionProvider",
  *     "translation" = "Drupal\helfi_tpr\Entity\TranslationHandler",

--- a/src/Plugin/views/filter/Status.php
+++ b/src/Plugin/views/filter/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_tpr\Plugin\views\filter;
 
 use Drupal\views\Plugin\views\filter\FilterPluginBase;

--- a/src/Plugin/views/filter/Status.php
+++ b/src/Plugin/views/filter/Status.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\helfi_tpr\Plugin\views\filter;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\views\Plugin\views\filter\FilterPluginBase;
 
 /**

--- a/src/Plugin/views/filter/Status.php
+++ b/src/Plugin/views/filter/Status.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\helfi_tpr\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Filter by published status.
+ *
+ * @ingroup views_filter_handlers
+ *
+ * @ViewsFilter("tpr_status")
+ */
+class Status extends FilterPluginBase {
+
+  public function adminSummary() {}
+
+  protected function operatorForm(&$form, FormStateInterface $form_state) {}
+
+  public function canExpose() {
+    return FALSE;
+  }
+
+  public function query() {
+    $table = $this->ensureMyTable();
+    $snippet = "$table.content_translation_status = 1 OR ***VIEW_UNPUBLISHED_TPR_ENTITIES*** = 1";
+    $this->query->addWhereExpression($this->options['group'], $snippet);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    $contexts = parent::getCacheContexts();
+
+    $contexts[] = 'user';
+
+    return $contexts;
+  }
+
+}

--- a/src/Plugin/views/filter/Status.php
+++ b/src/Plugin/views/filter/Status.php
@@ -14,14 +14,16 @@ use Drupal\views\Plugin\views\filter\FilterPluginBase;
  */
 class Status extends FilterPluginBase {
 
-  public function adminSummary() {}
-
-  protected function operatorForm(&$form, FormStateInterface $form_state) {}
-
+  /**
+   * {@inheritdoc}
+   */
   public function canExpose() {
     return FALSE;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function query() {
     $table = $this->ensureMyTable();
     $snippet = "$table.content_translation_status = 1 OR ***VIEW_UNPUBLISHED_TPR_ENTITIES*** = 1";

--- a/src/TprViewsData.php
+++ b/src/TprViewsData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_tpr;
 
 use Drupal\views\EntityViewsData;

--- a/src/TprViewsData.php
+++ b/src/TprViewsData.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\helfi_tpr;
+
+use Drupal\views\EntityViewsData;
+
+/**
+ * Provides the views data for TPR entity types.
+ */
+class TprViewsData extends EntityViewsData {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getViewsData() {
+    $data = parent::getViewsData();
+
+    // Get data table dynamically since this has to work with all TPR entities.
+    $data_table = $this->entityType->getDataTable();
+    if ($data_table) {
+      $data[$data_table]['status_extra'] = [
+        'title' => $this->t('Published status or admin user'),
+        'help' => $this->t('Filters out unpublished content if the current user cannot view it.'),
+        'filter' => [
+          'field' => 'content_translation_status',
+          'id' => 'tpr_status',
+          'label' => $this->t('Published status or admin user'),
+        ],
+      ];
+    }
+
+    return $data;
+  }
+
+}


### PR DESCRIPTION
## Custom "status or permission" filter for TPR entity views
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/UHF-4643

This adds a new custom views filter for all TPR entities that filters out unpublished entities if the current user doesn't have permissions to view them. Depends on the permissions being named something like `view unpublished [tpr_entity_id]`.

Doesn't include any configuration changes yet for any views.

## To test
* Make sure you have an up-to-date instance:
  * `git pull origin dev`
  * `make fresh` 
* `composer require drupal/helfi_tpr:dev-UHF-4643-unpublished-services`
* Edit one of the views that concerns TPR entities, for example: /admin/structure/views/view/tpr_unit_list
  * Add a new filter and find the new one, which should be called: "Published status or admin user" or "Julkaisutila tai ylläpitokäyttäjä"
  * Remove the "view unpublished [tpr_entity_id]" permissions from some user roles (such as content_producers).
  * Log in as an user with that role and check that unpublished entities aren't visible: /admin/content/integrations/tpr-unit

## Review the functionality
* Does this actually fix the problem outlined in the ticket?
* Are there any views or content lists that this should work with but doesn't? For example content list views that are visible to anonymous users.
* Anything wrong with the code?
  