### PR TITLE
Remove readonly_field_widget from view display options

### DIFF
--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -675,9 +675,6 @@ function helfi_tpr_update_8038() : void {
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('form', [
         'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayOptions('view', [
-        'type' => 'readonly_field_widget',
       ]);
 
     foreach ($fields as $name => $field) {

--- a/src/Entity/OntologyWordDetails.php
+++ b/src/Entity/OntologyWordDetails.php
@@ -113,9 +113,6 @@ class OntologyWordDetails extends TprEntityBase {
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayOptions('form', [
         'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayOptions('view', [
-        'type' => 'readonly_field_widget',
       ]);
 
     return $fields;


### PR DESCRIPTION
# Remove readonly_field_widget from view display options

This caused error when importing configs: "Unexpected error during import (–––): The readonly_field_widget plugin does not exist".

## How to test
* Check https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/134 for instructions.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/134