### PR TITLE
Fix provided languages views filter option

### DIFF
--- a/src/Plugin/views/filter/ProvidedLanguages.php
+++ b/src/Plugin/views/filter/ProvidedLanguages.php
@@ -36,7 +36,7 @@ class ProvidedLanguages extends InOperator {
     return [
       'fi' => t('Finnish'),
       'sv' => t('Swedish'),
-      'se' => t('Northern Sami'),
+      'se' => t('North Sami'),
     ];
   }
 


### PR DESCRIPTION
Use correct provided languages views filter option.
Check instructions from https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/144.