### PR TITLE
UHF-5473: Group daycare search results to avoid duplicate rows

### DIFF
--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
@@ -260,4 +261,11 @@ function helfi_tpr_tpr_errand_service_access(EntityInterface $entity, $operation
   }
 
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function helfi_tpr_query_owd_relationship_alter(AlterableInterface $query) : void {
+  $query->groupBy('id');
 }

--- a/src/Plugin/views/relationship/TagOwdRelationship.php
+++ b/src/Plugin/views/relationship/TagOwdRelationship.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\views\relationship;
+
+use Drupal\views\Plugin\views\relationship\RelationshipPluginBase;
+
+/**
+ * Tags queries for ontology word details relationship.
+ *
+ * @ingroup views_relationship_handlers
+ *
+ * @ViewsRelationship("tag_owd_relationship")
+ */
+class TagOwdRelationship extends RelationshipPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    parent::query();
+    $this->query->addTag('owd_relationship');
+  }
+
+}

--- a/src/TprViewsData.php
+++ b/src/TprViewsData.php
@@ -48,8 +48,9 @@ class TprViewsData extends EntityViewsData {
       'relationship' => [
         'base' => 'tpr_ontology_word_details_field_data',
         'base field' => 'unit_id',
-        'field' => 'id',
-        'id' => 'standard',
+        'table' => 'tpr_unit',
+        'real field' => 'id',
+        'id' => 'tag_owd_relationship',
         'label' => t('Ontology word details field data'),
       ],
     ];


### PR DESCRIPTION
# Remove duplicate results from daycare search [UHF-5473](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5473)
Groups daycare search results to avoid duplicate rows.

## What was done
* When using this specific relationship with views, the views query is tagged and later altered to group by `id` column.
* This removes duplicate result rows caused by joining the `tpr_ontology_word_details_field_data` table.

## How to install
* Make sure your instance is up and running.
* Update the TPR module:
    * `composer require drupal/helfi_tpr:dev-UHF-5473-fix-daycare-search-same-results`
* Run `make drush-cr`

## How to test
* Navigate to a page containing daycare search.
* Test that:
  * duplicate entries are removed.
  * other units are not missing.
  * pagination still works.
  * results are still sorted correctly.
  * filters still work.
  * address search still works.
  * translated versions of the search page are also working.
