### PR TITLE
UHF-2976: Clean regions

### DIFF
--- a/templates/tpr-service.html.twig
+++ b/templates/tpr-service.html.twig
@@ -47,37 +47,7 @@
         {% block main_content %}
         {% endblock main_content %}
       </div>
-      {% if in_menu or sidebar_content or content.links|render %}
-        <div class="service__sidebar">
-          {% block sidebar_block %}
-          {% endblock sidebar_block%}
-
-          {% if content.links|render %}
-            <div class="sidebar-text sidebar-text--service-links has-title ">
-              <h2 class="sidebar-text__title">{{ 'Important links'|t }}</h2>
-              <div class="sidebar-text__text-content">{{ content.links }}</div>
-            </div>
-          {% endif %}
-        </div>
-      {% endif %}
     </div>
-
-    {% set service_units_view = drupal_view_result('service_units', 'service_units')|length %}
-
-    {% if service_units_view > 0 %}
-      <div class="service__content">
-    {% endif %}
-
-      {% if service_units_view > 0 %}
-        <div class="service__units">
-          {{ drupal_view('service_units', 'service_units') }}
-        </div>
-      {% endif %}
-
-    {% if service_units_view > 0 %}
-      </div>
-    {% endif %}
-
   </article>
 
 {% elseif view_mode == 'teaser' %}


### PR DESCRIPTION
# Clean regions [UHF-2976](https://helsinkisolutionoffice.atlassian.net/browse/UHF-2976)

## What was done
* Removed sidebar content and lower content from tpr-service.html.twig as these fields will be render in sidebar and lower_content blocks

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/292
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/366
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/148
* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/64
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/315
