### PR TITLE
UHF-5512: Add highlight connection support for TPR Units

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.exclusions=tests/**
+sonar.cpd.exclusions=src/Fixture/*

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -683,3 +683,19 @@ function helfi_tpr_update_8038() : void {
     }
   }
 }
+
+/**
+ * Add 'highlights' field to the TPR Unit entity.
+ */
+function helfi_tpr_update_8039() : void {
+  $fields['highlights'] = BaseFieldDefinition::create('tpr_connection')
+    ->setLabel(new TranslatableMarkup('Highlights'))
+    ->setTranslatable(TRUE)
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setDisplayConfigurable('view', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
+  }
+}

--- a/migrations/tpr_unit.yml
+++ b/migrations/tpr_unit.yml
@@ -29,17 +29,27 @@ process:
   id: id
   name: name
   services: service_descriptions
+  _opening_hours_connections:
+    plugin: array_element_equals
+    source: connections
+    value: OPENING_HOURS
+    key: type
   opening_hours:
     plugin: sub_process
-    source: connections
+    source: '@_opening_hours_connections'
     process:
-      # Only import opening hours
-      skip:
-        plugin: skip_on_value
-        not_equals: true
-        source: type
-        value: OPENING_HOURS
-        method: row
+      value: value
+      data: data
+      type: type
+  _highlight_connections:
+    plugin: array_element_equals
+    source: connections
+    value: HIGHLIGHT
+    key: type
+  highlights:
+    plugin: sub_process
+    source: '@_highlight_connections'
+    process:
       value: value
       data: data
       type: type

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -313,6 +313,11 @@ class Unit extends TprEntityBase {
       ->setLabel(new TranslatableMarkup('Show website link'))
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
+    $fields['highlights'] = BaseFieldDefinition::create('tpr_connection')
+      ->setLabel(new TranslatableMarkup('Highlights'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+      ->setDisplayConfigurable('view', TRUE);
 
     return $fields;
   }

--- a/src/Field/Connection/Highlight.php
+++ b/src/Field/Connection/Highlight.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Field\Connection;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Provides a domain object for TPR connection type of HIGHLIGHT.
+ */
+final class Highlight extends Connection {
+
+  /**
+   * The type name.
+   *
+   * @var string
+   */
+  public const TYPE_NAME = 'HIGHLIGHT';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields(): array {
+    return [
+      'name',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    return [
+      'name' => [
+        '#markup' => Html::escape($this->get('name')),
+      ],
+    ];
+  }
+
+}

--- a/src/Field/Connection/Repository.php
+++ b/src/Field/Connection/Repository.php
@@ -16,6 +16,7 @@ final class Repository {
    */
   protected array $map = [
     OpeningHour::TYPE_NAME => OpeningHour::class,
+    Highlight::TYPE_NAME => Highlight::class,
   ];
 
   /**

--- a/src/Fixture/Unit.php
+++ b/src/Fixture/Unit.php
@@ -570,16 +570,16 @@ Vantaan sairaala on opetussairaala, joten potilaiden hoitoon osallistuu sekÃ¤ lÃ
           [
             'unit_id' => 1,
             'section_type' => 'HIGHLIGHT',
-            'name_fi' => 'hilight fi 1',
-            'name_en' => 'hilight en 1',
-            'name_sv' => 'hilight sv 1',
+            'name_fi' => 'highlight fi 1',
+            'name_en' => 'highlight en 1',
+            'name_sv' => 'highlight sv 1',
           ],
           [
             'unit_id' => 1,
             'section_type' => 'HIGHLIGHT',
-            'name_fi' => 'hilight fi 2',
-            'name_en' => 'hilight en 2',
-            'name_sv' => 'hilight sv 2',
+            'name_fi' => 'highlight fi 2',
+            'name_en' => 'highlight en 2',
+            'name_sv' => 'highlight sv 2',
           ],
           [
             'unit_id' => 1,

--- a/src/Plugin/migrate/process/ArrayElementEquals.php
+++ b/src/Plugin/migrate/process/ArrayElementEquals.php
@@ -45,10 +45,12 @@ class ArrayElementEquals extends ProcessPluginBase {
     $matchValue = $this->configuration['value'];
     $key = $this->configuration['key'];
 
-    if (is_array($value) || $value instanceof \Traversable) {
-      if (!empty($value[$key]) && $value[$key] === $matchValue) {
-        return $value;
-      }
+    if (empty($value) || !is_array($value)) {
+      return [];
+    }
+
+    if (!empty($value[$key]) && $value[$key] === $matchValue) {
+      return $value;
     }
 
     return [];

--- a/src/Plugin/migrate/process/ArrayElementEquals.php
+++ b/src/Plugin/migrate/process/ArrayElementEquals.php
@@ -41,7 +41,7 @@ class ArrayElementEquals extends ProcessPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) : array {
     $matchValue = $this->configuration['value'];
     $key = $this->configuration['key'];
 

--- a/src/Plugin/migrate/process/ArrayElementEquals.php
+++ b/src/Plugin/migrate/process/ArrayElementEquals.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Only include array when element (with a given key) matches a given value.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "array_element_equals"
+ * )
+ *
+ * @code
+ * opening_hours_connections:
+ *   plugin: array_element_equals
+ *   source: connections
+ *   value: OPENING_HOURS
+ *   key: type
+ * @endcode
+ */
+class ArrayElementEquals extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    if (empty($configuration['value']) && !array_key_exists('value', $configuration)) {
+      throw new \InvalidArgumentException('ArrayElementEquals plugin is missing value configuration.');
+    }
+    if (empty($configuration['key']) && !array_key_exists('key', $configuration)) {
+      throw new \InvalidArgumentException('ArrayElementEquals plugin is missing key configuration.');
+    }
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $matchValue = $this->configuration['value'];
+    $key = $this->configuration['key'];
+
+    if (is_array($value) || $value instanceof \Traversable) {
+      if (!empty($value[$key]) && $value[$key] === $matchValue) {
+        return $value;
+      }
+    }
+
+    return [];
+  }
+
+}

--- a/tests/src/Functional/ConnectionFormatterTest.php
+++ b/tests/src/Functional/ConnectionFormatterTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\helfi_tpr\Functional;
 
 use Drupal\Core\Url;
 use Drupal\helfi_tpr\Entity\TprEntityBase;
+use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
 
 /**
@@ -25,14 +26,21 @@ class ConnectionFormatterTest extends CustomFieldFormatterTestBase {
       $openingHour = new OpeningHour();
       $openingHour->set('name', "Open $language 1");
 
-      $field = $entity->getTranslation($language)
+      $openingHoursField = $entity->getTranslation($language)
         ->get('opening_hours');
-      $field->appendItem($openingHour);
+      $openingHoursField->appendItem($openingHour);
 
       $openingHour = new OpeningHour();
       $openingHour->set('www', "https://localhost/$language")
         ->set('name', "Open $language 2");
-      $field->appendItem($openingHour);
+      $openingHoursField->appendItem($openingHour);
+
+      $highlight = new Highlight();
+      $highlight->set('name', "Highlight $language");
+      $highlightsField = $entity->getTranslation($language)
+        ->get('highlights');
+      $highlightsField->appendItem($highlight);
+
       $entity->save();
     }
 
@@ -55,6 +63,7 @@ class ConnectionFormatterTest extends CustomFieldFormatterTestBase {
         'Opening hours',
         "Open $language 1",
         "Open $language 2",
+        "Highlight $language",
       ];
 
       foreach ($strings as $string) {
@@ -80,6 +89,10 @@ class ConnectionFormatterTest extends CustomFieldFormatterTestBase {
     $display_repository = \Drupal::service('entity_display.repository');
     $display_repository->getViewDisplay('tpr_unit', 'tpr_unit')
       ->setComponent('opening_hours', [
+        'type' => 'tpr_connection',
+        'label' => 'above',
+      ])
+      ->setComponent('highlights', [
         'type' => 'tpr_connection',
         'label' => 'above',
       ])

--- a/tests/src/Functional/CustomFieldFormatterTestBase.php
+++ b/tests/src/Functional/CustomFieldFormatterTestBase.php
@@ -46,7 +46,6 @@ abstract class CustomFieldFormatterTestBase extends MigrationTestBase {
 
     $account = $this->createUser($this->getUserPermissions());
     $this->drupalLogin($account);
-
   }
 
   /**

--- a/tests/src/Kernel/UnitMigrationTest.php
+++ b/tests/src/Kernel/UnitMigrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_tpr\Kernel;
 
 use Drupal\helfi_tpr\Entity\Unit;
+use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
 
 /**
@@ -64,6 +65,9 @@ class UnitMigrationTest extends MigrationTestBase {
       $opening_hour = $translation->get('opening_hours')->get(1)->data;
       $this->assertInstanceOf(OpeningHour::class, $opening_hour);
       $this->assertEquals("https://localhost/$langcode", $opening_hour->get('www'));
+      $highlight = $translation->get('highlights')->get(0)->data;
+      $this->assertInstanceOf(Highlight::class, $highlight);
+      $this->assertEquals("highlight $langcode 1", $highlight->get('name'));
     }
 
     // Re-run migrate and make sure migrate map hash doesn't change.

--- a/tests/src/Unit/ConnectionRepositoryTest.php
+++ b/tests/src/Unit/ConnectionRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\Tests\helfi_tpr\Unit;
 
 use Drupal\helfi_tpr\Field\Connection\Connection;
+use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
 use Drupal\helfi_tpr\Field\Connection\Repository;
 use Drupal\Tests\UnitTestCase;
@@ -62,6 +63,7 @@ class ConnectionRepositoryTest extends UnitTestCase {
   public function getTestData() : array {
     return [
       [OpeningHour::TYPE_NAME],
+      [Highlight::TYPE_NAME],
     ];
   }
 

--- a/tests/src/Unit/ConnectionTest.php
+++ b/tests/src/Unit/ConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tpr\Unit;
 
+use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
 use Drupal\Tests\UnitTestCase;
 
@@ -40,6 +41,29 @@ class ConnectionTest extends UnitTestCase {
 
     $object->set('www', 'https://localhost');
     $this->assertNotEmpty($object->build());
+  }
+
+  /**
+   * Tests highlights.
+   *
+   * @covers \Drupal\helfi_tpr\Field\Connection\Highlight::build
+   * @covers \Drupal\helfi_tpr\Field\Connection\Highlight::getFields
+   * @covers ::set
+   * @covers ::get
+   * @covers ::isValidField
+   */
+  public function testHighlights() : void {
+    $object = new Highlight();
+    $this->assertEquals('HIGHLIGHT', $object::TYPE_NAME);
+    $object->set('name', 'Some information.');
+    $this->assertNotEmpty($object->build());
+
+    // Make sure we can override data.
+    $object->set('name', 'override');
+    $this->assertNotEmpty($object->build());
+    $this->assertEquals('override', $object->get('name'));
+
+    $this->assertEquals(['name'], $object->getFields());
   }
 
   /**


### PR DESCRIPTION
# Add highlight connection support [UHF-5512](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5512)
Import Highlight connections so that they can be used with unit contact cards.

## What was done
* Added Highlight field to TPR Units.
* Added Highlight connection.
* Import highlight connections to the new highlight field.
  * Also needed to change how the Opening hours connections are imported at the migration config. When the highlight connection was added to the connection repository, the connections source includes both opening hours and hightlights, and this caused the `skip_on_value` process to skip unit rows.

## How to install
* Make sure your instance is up and running on latest dev branch.
* Update the Helfi TPR module:
  * `composer require drupal/helfi_tpr:dev-UHF-5512-tpr-unit-highlights`
* Run `make drush-updb`
* Run `make drush-cr`

## How to test
* Run `make shell` and the import TPR units:
  * `drush migrate:import tpr_unit`
* The other PR can be used to check that the highlights are imported by viewing them with unit contact cards.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/380
