### PR TITLE
UHF-6692: Add language content config for tpr_ontology_word_details

### DIFF
--- a/config/install/language.content_settings.tpr_ontology_word_details.tpr_ontology_word_details.yml
+++ b/config/install/language.content_settings.tpr_ontology_word_details.tpr_ontology_word_details.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - helfi_tpr
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: tpr_ontology_word_details.tpr_ontology_word_details
+target_entity_type_id: tpr_ontology_word_details
+target_bundle: tpr_ontology_word_details
+default_langcode: site_default
+language_alterable: true


### PR DESCRIPTION
# [UHF-6692](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6692)

## What was done
* Added missing language content config for tpr_ontology_word_details.
  * Now, when installing the module, there is no more missing translation created ja translation changed fields.
  * Also, there is no longer an error "InvalidArgumentException: The timestamp must be numeric." when listing the tpr_ontology_word_details items.

## How to test
* Check https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/120 which includes the fix.