### PR TITLE
UHF-7276: Changed version constraint to work with any branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,14 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.0",
-        "drupal/helfi_api_base": "^2.0 || dev-main",
+        "drupal/helfi_api_base": "*",
         "drupal/address": "~1.0",
         "drupal/readonly_field_widget": "^1.0",
         "drupal/twig_tweak": "^2.0 || ^3.0",
         "drupal/views_infinite_scroll": "^2.0"
+    },
+    "conflict": {
+        "drupal/helfi_api_base": "<2.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",


### PR DESCRIPTION
To test this:

1. Attempt to run `composer require drupal/helfi_api_base:dev-UHF-7265` in any project using TPR
2. Composer should fail to `Your requirements could not be resolved to an installable set of packages.` error
3. Update TPR module `composer require drupal/helfi_tpr:dev-UHF-7276`
4. Re-run step 1 and make sure API base is installed