### PR TITLE
UHF-8018: Fix for TPR Service metatag description

### DIFF
--- a/helfi_tpr.tokens.inc
+++ b/helfi_tpr.tokens.inc
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\helfi_tpr\Entity\Service;
 use Drupal\helfi_tpr\Entity\Unit;
 
 /**
@@ -88,6 +89,9 @@ function helfi_tpr_tokens(
       if ($name === 'picture') {
         $replacements[$original] = $entity->getPictureUrl();
       }
+    }
+
+    if ($entity instanceof Unit || $entity instanceof Service) {
       if ($name === 'description:value') {
         $replacements[$original] = $entity->getDescription('value');
       }

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_tpr\Entity;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Webmozart\Assert\Assert;
 
 /**
  * Defines the tpr_service entity class.
@@ -142,6 +143,17 @@ class Service extends TprEntityBase {
     }, $values);
 
     return array_search($errand_service->id(), $ids);
+  }
+
+  /**
+   * Gets the description.
+   *
+   * @return string|null
+   *   The description.
+   */
+  public function getDescription(string $key) : ? string {
+    Assert::oneOf($key, ['value', 'summary', 'format']);
+    return $this->get('description')->{$key};
   }
 
   /**


### PR DESCRIPTION
# [UHF-8018](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8018)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add token for TPR Service description so that it can be used for metatag description

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the helfi_tpr
    * `composer require drupal/helfi_platform_config:dev-UHF-8018_tpr_service_metatag_description_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to TPR service page and using the browser inspector make sure that the metatag description of any TPR service with a description has it written on the head-tag. For example like this: `<meta name="description" content="Kaupungin lähellä oleva luonto, laajat puistot ja metsät ovat kaikkien vapaasti käytettävissä erilaisiin vapaa-ajan harrasteisiin.">`
* [ ] Check that code follows our standards


[UHF-8018]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ