### PR TITLE
UHF-7334: Run opening hour content through _filter_autop to format it properly

### DIFF
--- a/helfi_tpr.info.yml
+++ b/helfi_tpr.info.yml
@@ -1,21 +1,20 @@
 name: HELfi TPR integration
 type: module
 package: Custom
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
-  - helfi_api_base
-  - text
-  - address
-  - link
-  - menu_link_content
-  - migrate
-  - content_translation
-  - language
-  - readonly_field_widget
-  - media
-  - twig_tweak
-  - telephone
-  - views
+  - helfi_api_base:helfi_api_base
+  - drupal:text
+  - address:address
+  - drupal:link
+  - drupal:menu_link_content
+  - drupal:migrate
+  - drupal:content_translation
+  - drupal:language
+  - readonly_field_widget:readonly_field_widget
+  - drupal:media
+  - twig_tweak:twig_tweak
+  - drupal:telephone
+  - drupal:views
 'interface translation project': helfi_tpr
 'interface translation server pattern': modules/contrib/helfi_tpr/translations/%language.po

--- a/modules/helfi_address_search/helfi_address_search.info.yml
+++ b/modules/helfi_address_search/helfi_address_search.info.yml
@@ -2,7 +2,6 @@ name: HELfi Address search
 type: module
 description: Adds address search feature to views that lists units.
 package: HELfi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
-  - helfi_tpr
+  - helfi_tpr:helfi_tpr

--- a/modules/helfi_school_addons/helfi_school_addons.info.yml
+++ b/modules/helfi_school_addons/helfi_school_addons.info.yml
@@ -2,8 +2,7 @@ name: HELfi School addons
 type: module
 description: Adds school specific features. Currently used with the high school search.
 package: HELfi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 configure: helfi_school_addons.admin_form
 dependencies:
-  - helfi_tpr
+  - helfi_tpr:helfi_tpr

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -33,9 +33,15 @@ final class OpeningHour extends Connection {
    * {@inheritdoc}
    */
   public function build(): array {
+    $markup = Html::escape($this->get('name'));
+
+    if (function_exists('_filter_autop')) {
+      $markup = _filter_autop($markup);
+    }
+
     $build = [
       'name' => [
-        '#markup' => Html::escape($this->get('name')),
+        '#markup' => $markup,
       ],
     ];
 

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -33,16 +33,9 @@ final class OpeningHour extends Connection {
    * {@inheritdoc}
    */
   public function build(): array {
-    $markup = Html::escape($this->get('name'));
-
-    // The _filter_autop is provided by 'filter' module
-    if (function_exists('_filter_autop')) {
-      $markup = _filter_autop($markup);
-    }
-
     $build = [
       'name' => [
-        '#markup' => $markup,
+        '#markup' => _filter_autop(Html::escape($this->get('name'))),
       ],
     ];
 

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -33,9 +33,15 @@ final class OpeningHour extends Connection {
    * {@inheritdoc}
    */
   public function build(): array {
+    $markup = Html::escape($this->get('name'));
+
+    if (function_exists('_filter_autop')) {
+      $markup = _filter_autop($markup);
+    }
+
     $build = [
       'name' => [
-        '#markup' => _filter_autop(Html::escape($this->get('name'))),
+        '#markup' => $markup,
       ],
     ];
 

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -35,6 +35,7 @@ final class OpeningHour extends Connection {
   public function build(): array {
     $markup = Html::escape($this->get('name'));
 
+    // The _filter_autop is provided by 'filter' module
     if (function_exists('_filter_autop')) {
       $markup = _filter_autop($markup);
     }

--- a/src/Field/FieldDefinition.php
+++ b/src/Field/FieldDefinition.php
@@ -17,7 +17,7 @@ final class FieldDefinition extends BaseFieldDefinition {
   /**
    * {@inheritdoc}
    */
-  public function isBaseField() {
+  public function isBaseField() : bool {
     return FALSE;
   }
 

--- a/tests/modules/helfi_tpr_test/helfi_tpr_test.info.yml
+++ b/tests/modules/helfi_tpr_test/helfi_tpr_test.info.yml
@@ -4,4 +4,4 @@ core_version_requirement: ^9 || ^10
 description: 'Provides default views for tests.'
 package: Testing
 dependencies:
-  - drupal:helfi_tpr
+  - helfi_tpr:helfi_tpr


### PR DESCRIPTION
## How to install

- `composer require drupal/helfi_tpr:dev-UHF-7334`

## How to test

- Open some TPR unit with opening hours, for example: `/tpr-unit/31791`.
- Make sure newlines (\n) are converted into html tags (`<br>` and `<p>`)

It should look something like: 
![image](https://user-images.githubusercontent.com/771113/229031291-8611894a-21e1-42fa-b9b9-05576b12b011.png)

Compared to: 
![image](https://user-images.githubusercontent.com/771113/229031345-0d17d2f9-99b0-44dc-ad79-f8c7cc43694c.png)

where everything is mushed together.