### PR TITLE
UHF-8290 getCurrentLanguage parameter 

### DIFF
--- a/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
@@ -70,7 +70,7 @@ abstract class SchoolDetailsBase extends InOperator {
     $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
     $this->query->addRelationship('owd_fd', $owdFdJoin, 'tpr_unit_field_data');
 
-    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
+    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
     $this->query->addWhere('AND', 'owd_fd.langcode', $language);
     $this->query->addWhere('AND', 'owd_fd.ontologyword_id', $wordId);
 
@@ -105,7 +105,7 @@ abstract class SchoolDetailsBase extends InOperator {
       return [];
     }
 
-    $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
+    $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
     $schoolYear = SchoolUtility::getCurrentSchoolYear();
     if ($schoolYear === NULL) {
       return [];

--- a/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/SchoolDetailsBase.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_school_addons\Plugin\views\filter;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\helfi_school_addons\SchoolUtility;
 use Drupal\helfi_tpr\Entity\OntologyWordDetails;
 use Drupal\views\Plugin\views\display\DisplayPluginBase;
@@ -69,7 +70,7 @@ abstract class SchoolDetailsBase extends InOperator {
     $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
     $this->query->addRelationship('owd_fd', $owdFdJoin, 'tpr_unit_field_data');
 
-    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
     $this->query->addWhere('AND', 'owd_fd.langcode', $language);
     $this->query->addWhere('AND', 'owd_fd.ontologyword_id', $wordId);
 
@@ -104,7 +105,7 @@ abstract class SchoolDetailsBase extends InOperator {
       return [];
     }
 
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
     $schoolYear = SchoolUtility::getCurrentSchoolYear();
     if ($schoolYear === NULL) {
       return [];

--- a/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_school_addons\Plugin\views\filter;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\helfi_school_addons\SchoolUtility;
 use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\filter\InOperator;
@@ -64,7 +65,7 @@ class StudyProgrammeType extends InOperator {
     $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
     $this->query->addRelationship('owd_fd_spt', $owdFdJoin, 'tpr_unit_field_data');
 
-    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
     $this->query->addWhere('AND', 'owd_fd_spt.langcode', $language);
 
     // Join with tpr_ontology_word_details__detail_items table.

--- a/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
+++ b/modules/helfi_school_addons/src/Plugin/views/filter/StudyProgrammeType.php
@@ -65,7 +65,7 @@ class StudyProgrammeType extends InOperator {
     $owdFdJoin = Views::pluginManager('join')->createInstance('standard', $owdFdConfiguration);
     $this->query->addRelationship('owd_fd_spt', $owdFdJoin, 'tpr_unit_field_data');
 
-    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
+    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
     $this->query->addWhere('AND', 'owd_fd_spt.langcode', $language);
 
     // Join with tpr_ontology_word_details__detail_items table.


### PR DESCRIPTION
Called on content pages. TYPE_CONTENT required.

Go to `/fi/kasvatus-ja-koulutus/lukiokoulutus/lukiot`. Content is now shown based on content language.