### PR TITLE
UHF-8430: Added municipality to the address search query.

### DIFF
--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -136,6 +136,7 @@ class AddressSearch extends FilterPluginBase {
           'page' => '1',
           'page_size' => '1',
           'language' => $language,
+          'municipality' => 'helsinki',
         ],
       ]);
     }


### PR DESCRIPTION
## [UHF-8430](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8430)

## What was done
This PR adds `&municipality=Hhelsinki` to the unit address search.

## How to install
* Make sure your kasko instance is up and running on latest dev branch (SOTE for example).
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi TPR module
    * `composer require drupal/drupal-module-helfi-tpr:dev-UHF-8430-Unit-search-municipality-bug`
* Run `make drush-cr`

## How to test
* Open https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/varhaiskasvatus/varhaiskasvatus-paivakodissa/etsi-kunnallisia-paivakoteja and search for "Mannerheimintie 1" and check the first result. It should be rather close, not far like 80km away.

[UHF-8430]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ