### PR TITLE
UHF-7748: throws error because of missing # from the array key

### DIFF
--- a/modules/helfi_address_search/src/Plugin/views/area/AddressSearchInfo.php
+++ b/modules/helfi_address_search/src/Plugin/views/area/AddressSearchInfo.php
@@ -25,8 +25,8 @@ class AddressSearchInfo extends AreaPluginBase {
    *   NULL: the search was not performed.
    */
   protected function getSearchStatus(): ?bool {
-    if (isset($this->view->element['address_search_succeed'])) {
-      return $this->view->element['address_search_succeed'];
+    if (isset($this->view->element['#address_search_succeed'])) {
+      return $this->view->element['#address_search_succeed'];
     }
     return NULL;
   }

--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -224,8 +224,8 @@ class AddressSearch extends FilterPluginBase {
    *   ViewExecutable element array.
    */
   protected static function setSearchStatus(array $element, bool $succeed): array {
-    if (!isset($element['address_search_succeed'])) {
-      $element['address_search_succeed'] = $succeed;
+    if (!isset($element['#address_search_succeed'])) {
+      $element['#address_search_succeed'] = $succeed;
     }
     return $element;
   }


### PR DESCRIPTION
Reproduce bug:
- Setup kasko with make fresh
- Go to `https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/varhaiskasvatus/varhaiskasvatus-paivakodissa/etsi-kunnallisia-paivakoteja?address_search=2022`
- run `docker logs helfi-kasko-app` (or go check the kasko app logs from docker desktop)
  - You should see the error with `address_search_succeed`

Test fix:
- (if you didn't reproduce the bug:) Setup kasko with make fresh 
- Run `composer require drupal/helfi_tpr:dev-UHF-7748_tpr_error`
- Run `make drush-cr`
- Go to `https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/varhaiskasvatus/varhaiskasvatus-paivakodissa/etsi-kunnallisia-paivakoteja?address_search=2022`
- run `docker logs helfi-kasko-app`(or go check the kasko app logs from docker desktop)
  - You should not see any errors
  - Page should render normally