### PR TITLE
UFH-8595: Added multiple missing fields to Units

### DIFF
--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -227,3 +227,57 @@ function helfi_tpr_update_8043() : void {
       ->installFieldStorageDefinition($name, 'tpr_service', 'helfi_tpr', $field);
   }
 }
+
+/**
+ * Add multiple missing fields to Unit entity.
+ */
+function helfi_tpr_update_8044() : void {
+  $fields['other_info'] = BaseFieldDefinition::create('tpr_connection')
+    ->setLabel(new TranslatableMarkup('Further information'))
+    ->setDescription(new TranslatableMarkup('The "OTHER_INFO" connection type'))
+    ->setTranslatable(TRUE)
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  $fields['price_info'] = BaseFieldDefinition::create('tpr_connection')
+    ->setLabel(new TranslatableMarkup('Charges'))
+    ->setDescription(new TranslatableMarkup('The "PRICE" connection type'))
+    ->setTranslatable(TRUE)
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  $fields['links'] = BaseFieldDefinition::create('tpr_connection')
+    ->setLabel(new TranslatableMarkup('Web sites'))
+    ->setDescription(new TranslatableMarkup('The "LINK" connection type'))
+    ->setTranslatable(TRUE)
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  $fields['contacts'] = BaseFieldDefinition::create('tpr_connection')
+    ->setLabel(new TranslatableMarkup('Other contact information'))
+    ->setDescription(new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'))
+    ->setTranslatable(TRUE)
+    ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
+  }
+}

--- a/migrations/tpr_unit.yml
+++ b/migrations/tpr_unit.yml
@@ -56,6 +56,54 @@ process:
       value: value
       data: data
       type: type
+  _other_info_connections:
+      plugin: array_element_equals
+      source: connections
+      value: OTHER_INFO
+      key: type
+  other_info:
+    plugin: sub_process
+    source: '@_other_info_connections'
+    process:
+      value: value
+      data: data
+      type: type
+  _price_info_connections:
+      plugin: array_element_equals
+      source: connections
+      value: PRICE
+      key: type
+  price_info:
+    plugin: sub_process
+    source: '@_price_info_connections'
+    process:
+      value: value
+      data: data
+      type: type
+  _links_connections:
+      plugin: array_element_equals
+      source: connections
+      value: LINK
+      key: type
+  links:
+    plugin: sub_process
+    source: '@_links_connections'
+    process:
+      value: value
+      data: data
+      type: type
+  _contacts_connections:
+      plugin: array_element_equals
+      source: connections
+      value: PHONE_OR_EMAIL
+      key: type
+  contacts:
+    plugin: sub_process
+    source: '@_contacts_connections'
+    process:
+      value: value
+      data: data
+      type: type
   accessibility_sentences:
     plugin: sub_process
     source: accessibility_sentences

--- a/src/Entity/Listing/ListBuilder.php
+++ b/src/Entity/Listing/ListBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Entity\Listing;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Routing\RedirectDestinationInterface;

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -336,6 +336,40 @@ class Unit extends TprEntityBase {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ]);
+    $fields['other_info'] = BaseFieldDefinition::create('tpr_connection')
+      ->setLabel(new TranslatableMarkup('Further information'))
+      ->setDescription(new TranslatableMarkup('The "OTHER_INFO" connection type'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+    $fields['price_info'] = BaseFieldDefinition::create('tpr_connection')
+      ->setLabel(new TranslatableMarkup('Charges'))
+      ->setDescription(new TranslatableMarkup('The "PRICE" connection type'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+    $fields['links'] = BaseFieldDefinition::create('tpr_connection')
+      ->setLabel(new TranslatableMarkup('Web sites'))
+      ->setDescription(new TranslatableMarkup('The "LINK" connection type'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+    $fields['contacts'] = BaseFieldDefinition::create('tpr_connection')
+      ->setLabel(new TranslatableMarkup('Other contact information'))
+      ->setDescription(new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'))
+      ->setTranslatable(TRUE)
+      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
 
     return $fields;
   }

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -342,14 +342,20 @@ class Unit extends TprEntityBase {
       ->setTranslatable(TRUE)
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ]);
     $fields['price_info'] = BaseFieldDefinition::create('tpr_connection')
       ->setLabel(new TranslatableMarkup('Charges'))
       ->setDescription(new TranslatableMarkup('The "PRICE" connection type'))
       ->setTranslatable(TRUE)
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ]);
     $fields['links'] = BaseFieldDefinition::create('tpr_connection')
       ->setLabel(new TranslatableMarkup('Web sites'))
       ->setDescription(new TranslatableMarkup('The "LINK" connection type'))

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -301,6 +301,10 @@ class Unit extends TprEntityBase {
       ->setDescription(new TranslatableMarkup('The "OPENING_HOURS" connection type'))
       ->setTranslatable(TRUE)
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
     $fields['provided_languages'] = BaseFieldDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Provided languages'))
@@ -323,6 +327,10 @@ class Unit extends TprEntityBase {
       ->setLabel(new TranslatableMarkup('Highlights'))
       ->setTranslatable(TRUE)
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
     $fields['ontologyword_ids'] = BaseFieldDefinition::create('integer')
       ->setLabel(new TranslatableMarkup('Ontologyword IDs'))

--- a/src/Field/Connection/Link.php
+++ b/src/Field/Connection/Link.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Field\Connection;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Url;
+
+/**
+ * Provides a domain object for TPR connection type of LINK.
+ */
+final class Link extends Connection {
+
+  /**
+   * The type name.
+   *
+   * @var string
+   */
+  public const TYPE_NAME = 'LINK';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields(): array {
+    return [
+      'name',
+      'www',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $markup = Html::escape($this->get('name'));
+
+    if (function_exists('_filter_autop')) {
+      $markup = _filter_autop($markup);
+    }
+
+    $build = [
+      'name' => [
+        '#markup' => $markup,
+      ],
+    ];
+
+    if ($link = $this->get('www')) {
+      try {
+        return [
+          'www' => [
+            '#title' => $this->get('name'),
+            '#type' => 'link',
+            '#url' => Url::fromUri($link),
+          ],
+        ];
+      }
+      catch (\InvalidArgumentException) {
+      }
+    }
+
+    return $build;
+  }
+
+}

--- a/src/Field/Connection/Link.php
+++ b/src/Field/Connection/Link.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_tpr\Field\Connection;
 /**
  * Provides a domain object for TPR connection type of LINK.
  */
-final class Link extends TextWithLinkBase {
+final class Link extends TextWithLink {
 
   /**
    * The type name.

--- a/src/Field/Connection/Link.php
+++ b/src/Field/Connection/Link.php
@@ -4,13 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_tpr\Field\Connection;
 
-use Drupal\Component\Utility\Html;
-use Drupal\Core\Url;
-
 /**
  * Provides a domain object for TPR connection type of LINK.
  */
-final class Link extends Connection {
+final class Link extends TextWithLinkBase {
 
   /**
    * The type name.
@@ -18,48 +15,5 @@ final class Link extends Connection {
    * @var string
    */
   public const TYPE_NAME = 'LINK';
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getFields(): array {
-    return [
-      'name',
-      'www',
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function build(): array {
-    $markup = Html::escape($this->get('name'));
-
-    if (function_exists('_filter_autop')) {
-      $markup = _filter_autop($markup);
-    }
-
-    $build = [
-      'name' => [
-        '#markup' => $markup,
-      ],
-    ];
-
-    if ($link = $this->get('www')) {
-      try {
-        return [
-          'www' => [
-            '#title' => $this->get('name'),
-            '#type' => 'link',
-            '#url' => Url::fromUri($link),
-          ],
-        ];
-      }
-      catch (\InvalidArgumentException) {
-      }
-    }
-
-    return $build;
-  }
 
 }

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_tpr\Field\Connection;
 /**
  * Provides a DTO for TPR connection type of OPENING_HOURS.
  */
-final class OpeningHour extends TextWithLinkBase {
+final class OpeningHour extends TextWithLink {
 
   /**
    * The type name.

--- a/src/Field/Connection/OpeningHour.php
+++ b/src/Field/Connection/OpeningHour.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_tpr\Field\Connection;
 /**
  * Provides a DTO for TPR connection type of OPENING_HOURS.
  */
-final class OpeningHour extends OpeningHourBase {
+final class OpeningHour extends TextWithLinkBase {
 
   /**
    * The type name.

--- a/src/Field/Connection/OpeningHourObject.php
+++ b/src/Field/Connection/OpeningHourObject.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_tpr\Field\Connection;
 /**
  * Provides a DTO for TPR connection type of OPENING_HOUR_OBJECT.
  */
-final class OpeningHourObject extends TextWithLinkBase {
+final class OpeningHourObject extends TextWithLink {
 
   /**
    * The type name.

--- a/src/Field/Connection/OpeningHourObject.php
+++ b/src/Field/Connection/OpeningHourObject.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_tpr\Field\Connection;
 /**
  * Provides a DTO for TPR connection type of OPENING_HOUR_OBJECT.
  */
-final class OpeningHourObject extends OpeningHourBase {
+final class OpeningHourObject extends TextWithLinkBase {
 
   /**
    * The type name.

--- a/src/Field/Connection/OtherInfo.php
+++ b/src/Field/Connection/OtherInfo.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Field\Connection;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Provides a domain object for TPR connection type of OPENING_HOUR.
+ */
+final class OtherInfo extends Connection {
+
+  /**
+   * The type name.
+   *
+   * @var string
+   */
+  public const TYPE_NAME = 'OTHER_INFO';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields(): array {
+    return [
+      'name',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $markup = Html::escape($this->get('name'));
+
+    if (function_exists('_filter_autop')) {
+      $markup = _filter_autop($markup);
+    }
+
+    return [
+      'name' => [
+        '#markup' => $markup,
+      ],
+    ];
+  }
+
+}

--- a/src/Field/Connection/PhoneOrEmail.php
+++ b/src/Field/Connection/PhoneOrEmail.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Field\Connection;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Provides a domain object for TPR connection type of PHONE_OR_EMAIL.
+ */
+final class PhoneOrEmail extends Connection {
+
+  /**
+   * The type name.
+   *
+   * @var string
+   */
+  public const TYPE_NAME = 'PHONE_OR_EMAIL';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields(): array {
+    return [
+      'name',
+      'contact_person',
+      'phone',
+      'email',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $fields = $this->getFields();
+    $fields_data = [];
+
+    foreach ($fields as $field) {
+      if (!$this->get($field)) {
+        continue;
+      }
+
+      $data = Html::escape($this->get($field));
+
+      $fields_data[] = $data;
+    }
+
+    $build = [
+      'contact' => [
+        '#markup' => '<p>' . implode('<br>', $fields_data) . '</p>',
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/src/Field/Connection/Price.php
+++ b/src/Field/Connection/Price.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Field\Connection;
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Provides a domain object for TPR connection type of PRICE.
+ */
+final class Price extends Connection {
+
+  /**
+   * The type name.
+   *
+   * @var string
+   */
+  public const TYPE_NAME = 'PRICE';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFields(): array {
+    return [
+      'name',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $markup = Html::escape($this->get('name'));
+
+    if (function_exists('_filter_autop')) {
+      $markup = _filter_autop($markup);
+    }
+
+    return [
+      'name' => [
+        '#markup' => $markup,
+      ],
+    ];
+  }
+
+}

--- a/src/Field/Connection/Repository.php
+++ b/src/Field/Connection/Repository.php
@@ -18,6 +18,10 @@ final class Repository {
     OpeningHour::TYPE_NAME => OpeningHour::class,
     OpeningHourObject::TYPE_NAME => OpeningHourObject::class,
     Highlight::TYPE_NAME => Highlight::class,
+    OtherInfo::TYPE_NAME => OtherInfo::class,
+    Price::TYPE_NAME => Price::class,
+    Link::TYPE_NAME => Link::class,
+    PhoneOrEmail::TYPE_NAME => PhoneOrEmail::class,
   ];
 
   /**

--- a/src/Field/Connection/TextWithLink.php
+++ b/src/Field/Connection/TextWithLink.php
@@ -10,7 +10,7 @@ use Drupal\Core\Url;
 /**
  * A base class for connections with text and link.
  */
-abstract class TextWithLinkBase extends Connection {
+abstract class TextWithLink extends Connection {
 
   /**
    * {@inheritdoc}

--- a/src/Field/Connection/TextWithLinkBase.php
+++ b/src/Field/Connection/TextWithLinkBase.php
@@ -8,9 +8,9 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
 
 /**
- * A base class for 'opening hour' connections.
+ * A base class for connections with text and link.
  */
-abstract class OpeningHourBase extends Connection {
+abstract class TextWithLinkBase extends Connection {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Field/FieldFormatter/ConnectionFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ConnectionFormatter.php
@@ -32,6 +32,7 @@ final class ConnectionFormatter extends FormatterBase {
       $element[$delta] = [
         '#type' => 'item',
         'content' => $item->data->build(),
+        '#parents' => [$delta],
       ];
     }
 

--- a/tests/src/Unit/ConnectionTest.php
+++ b/tests/src/Unit/ConnectionTest.php
@@ -6,7 +6,7 @@ namespace Drupal\Tests\helfi_tpr\Unit;
 
 use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
-use Drupal\helfi_tpr\Field\Connection\OpeningHourBase;
+use Drupal\helfi_tpr\Field\Connection\TextWithLinkBase;
 use Drupal\helfi_tpr\Field\Connection\OpeningHourObject;
 use Drupal\Tests\UnitTestCase;
 
@@ -21,14 +21,14 @@ class ConnectionTest extends UnitTestCase {
   /**
    * Tests opening hours.
    *
-   * @covers \Drupal\helfi_tpr\Field\Connection\OpeningHourBase::build
-   * @covers \Drupal\helfi_tpr\Field\Connection\OpeningHourBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::build
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
    * @covers ::set
    * @covers ::get
    * @covers ::isValidField
    * @dataProvider openingHourData
    */
-  public function testOpeningHours(OpeningHourBase $object) : void {
+  public function testOpeningHours(TextWithLinkBase $object) : void {
     $object->set('name', 'mon-wed 10-19');
     $this->assertNotEmpty($object->build());
 
@@ -71,10 +71,10 @@ class ConnectionTest extends UnitTestCase {
    *
    * @covers ::set
    * @covers ::isValidField
-   * @covers \Drupal\helfi_tpr\Field\Connection\OpeningHourBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
    * @dataProvider openingHourData
    */
-  public function testInvalidFieldName(OpeningHourBase $object) : void {
+  public function testInvalidFieldName(TextWithLinkBase $object) : void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Field "invalid_field" is not valid.');
     $object->set('invalid_field', 'value');
@@ -97,7 +97,7 @@ class ConnectionTest extends UnitTestCase {
    * Tests invalid data type.
    *
    * @dataProvider invalidFieldValueData
-   * @covers \Drupal\helfi_tpr\Field\Connection\OpeningHourBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
    * @covers ::set
    * @covers ::isValidField
    */
@@ -125,7 +125,7 @@ class ConnectionTest extends UnitTestCase {
    * Tests valid values.
    *
    * @dataProvider validFieldValueData
-   * @covers \Drupal\helfi_tpr\Field\Connection\OpeningHourBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
    * @covers ::set
    * @covers ::get
    * @covers ::isValidField

--- a/tests/src/Unit/ConnectionTest.php
+++ b/tests/src/Unit/ConnectionTest.php
@@ -6,8 +6,8 @@ namespace Drupal\Tests\helfi_tpr\Unit;
 
 use Drupal\helfi_tpr\Field\Connection\Highlight;
 use Drupal\helfi_tpr\Field\Connection\OpeningHour;
-use Drupal\helfi_tpr\Field\Connection\TextWithLinkBase;
 use Drupal\helfi_tpr\Field\Connection\OpeningHourObject;
+use Drupal\helfi_tpr\Field\Connection\TextWithLink;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -21,14 +21,14 @@ class ConnectionTest extends UnitTestCase {
   /**
    * Tests opening hours.
    *
-   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::build
-   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLink::build
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLink::getFields
    * @covers ::set
    * @covers ::get
    * @covers ::isValidField
    * @dataProvider openingHourData
    */
-  public function testOpeningHours(TextWithLinkBase $object) : void {
+  public function testOpeningHours(TextWithLink $object) : void {
     $object->set('name', 'mon-wed 10-19');
     $this->assertNotEmpty($object->build());
 
@@ -71,10 +71,10 @@ class ConnectionTest extends UnitTestCase {
    *
    * @covers ::set
    * @covers ::isValidField
-   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLink::getFields
    * @dataProvider openingHourData
    */
-  public function testInvalidFieldName(TextWithLinkBase $object) : void {
+  public function testInvalidFieldName(TextWithLink $object) : void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Field "invalid_field" is not valid.');
     $object->set('invalid_field', 'value');
@@ -97,7 +97,7 @@ class ConnectionTest extends UnitTestCase {
    * Tests invalid data type.
    *
    * @dataProvider invalidFieldValueData
-   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLink::getFields
    * @covers ::set
    * @covers ::isValidField
    */
@@ -125,7 +125,7 @@ class ConnectionTest extends UnitTestCase {
    * Tests valid values.
    *
    * @dataProvider validFieldValueData
-   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLinkBase::getFields
+   * @covers \Drupal\helfi_tpr\Field\Connection\TextWithLink::getFields
    * @covers ::set
    * @covers ::get
    * @covers ::isValidField

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -55,3 +55,15 @@ msgstr "Ylikirjoita arvo kentälle: @field_name"
 
 msgid "Override: Picture"
 msgstr "Oletuskuvan korvaava kuva"
+
+msgid "Further information"
+msgstr "Lisätietoja"
+
+msgid "Charges"
+msgstr "Hinnat"
+
+msgid "Web sites"
+msgstr "Muualla verkossa"
+
+msgid "Other contact information"
+msgstr "Muut yhteystiedot"

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -40,3 +40,15 @@ msgstr "Överskrida: @field_name"
 
 msgid "Override: Picture"
 msgstr "Bild som ersätter standardbilden"
+
+msgid "Further information"
+msgstr "Ytterligare uppgifter"
+
+msgid "Charges"
+msgstr "Priser"
+
+msgid "Web sites"
+msgstr "På webben"
+
+msgid "Other contact information"
+msgstr "Andra kontaktuppgifter"


### PR DESCRIPTION
# [UHF-8595](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595)
Units are missing multiple fields from TPR.

## What was done
- Added four missing fields to unit entities (charges, further informations, web sites, other contact information)

## How to install

* Make sure your `kuva` instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi TPR config
    * `composer require drupal/helfi_tpr:dev-UFH-8595_missing-unit-tpr-fields`
    * `composer require drupal/hdbt:dev-UHF-8595_missing-tpr-fields`
    * `composer require drupal/helfi_platform_config:dev-UHF-8595_tpr-unit-config-updates`
* Run `make drush-updb drush-cr drush-local-update`
* Run the migration `drush migrate:import tpr_unit --idlist 41047:fi,41047:sv,41047:en --update`

## How to test

- [x] Check https://helfi-kuva.docker.so/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/uimarannat/maauimalat/uimastadion and that the new fields are there.
- [x] Check that the translations applied.
- [x] Check that code follows our standards.

## Other PRs
Check also the other PRs which updates the unit template and display configs: https://github.com/City-of-Helsinki/drupal-hdbt/pull/690 & https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/538.

[UHF-8595]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ