### PR TITLE
UHF-8595: Fixed duplicated code

### DIFF
--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -358,9 +358,8 @@ class Unit extends TprEntityBase {
       $fields[$name] = BaseFieldDefinition::create('tpr_connection')
         ->setLabel($data['label'])
         ->setDescription(new TranslatableMarkup('The "@description" connection type', [
-            '@description' => $data['description'],
-          ])
-        )
+          '@description' => $data['description'],
+        ]))
         ->setTranslatable(TRUE)
         ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
         ->setDisplayOptions('form', [

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -352,19 +352,19 @@ class Unit extends TprEntityBase {
         'description' => new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'),
         'label' => new TranslatableMarkup('Other contact information'),
       ],
-     ];
+    ];
 
     foreach ($connectionFields as $name => $data) {
       $fields[$name] = BaseFieldDefinition::create('tpr_connection')
-       ->setLabel($data['label'])
-       ->setDescription($data['description'])
-       ->setTranslatable(TRUE)
-       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
-       ->setDisplayOptions('form', [
-         'type' => 'readonly_field_widget',
-       ])
-       ->setDisplayConfigurable('form', TRUE)
-       ->setDisplayConfigurable('view', TRUE);
+        ->setLabel($data['label'])
+        ->setDescription($data['description'])
+        ->setTranslatable(TRUE)
+        ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+        ->setDisplayOptions('form', [
+          'type' => 'readonly_field_widget',
+        ])
+        ->setDisplayConfigurable('form', TRUE)
+        ->setDisplayConfigurable('view', TRUE);
     }
 
     return $fields;

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -329,35 +329,38 @@ class Unit extends TprEntityBase {
 
     $connectionFields = [
       'links' => [
-        'description' => 'The "LINK" connection type',
-        'label' => 'Web sites',
+        'description' => 'LINK',
+        'label' => new TranslatableMarkup('Web sites'),
       ],
       'opening_hours' => [
-        'description' => 'The "OPENING_HOURS" connection type',
-        'label' => 'Opening hours',
+        'description' => 'OPENING_HOURS',
+        'label' => new TranslatableMarkup('Opening hours'),
       ],
       'highlights' => [
-        'description' => 'The "HIGHLIGHTS" connection type',
-        'label' => 'Highlights',
+        'description' => 'HIGHLIGHTS',
+        'label' => new TranslatableMarkup('Highlights'),
       ],
       'other_info' => [
-        'description' => 'The "OTHER_INFO" connection type',
-        'label' => 'Further information',
+        'description' => 'OTHER_INFO',
+        'label' => new TranslatableMarkup('Further information'),
       ],
       'price_info' => [
-        'description' => 'The "PRICE" connection type',
-        'label' => 'Charges',
+        'description' => 'PRICE',
+        'label' => new TranslatableMarkup('Charges'),
       ],
       'contacts' => [
-        'description' => 'The "PHONE_OR_EMAIL" connection type',
-        'label' => 'Other contact information',
+        'description' => 'PHONE_OR_EMAIL',
+        'label' => new TranslatableMarkup('Other contact information'),
       ],
     ];
 
     foreach ($connectionFields as $name => $data) {
       $fields[$name] = BaseFieldDefinition::create('tpr_connection')
-        ->setLabel(new TranslatableMarkup($data['label']))
-        ->setDescription(new TranslatableMarkup($data['description']))
+        ->setLabel($data['label'])
+        ->setDescription(new TranslatableMarkup('The "@description" connection type', [
+            '@description' => $data['description'],
+          ])
+        )
         ->setTranslatable(TRUE)
         ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
         ->setDisplayOptions('form', [

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -296,16 +296,6 @@ class Unit extends TprEntityBase {
       ->setTranslatable(TRUE)
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE);
-    $fields['opening_hours'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Opening hours'))
-      ->setDescription(new TranslatableMarkup('The "OPENING_HOURS" connection type'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
     $fields['provided_languages'] = BaseFieldDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Provided languages'))
       ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
@@ -323,15 +313,7 @@ class Unit extends TprEntityBase {
       ->setLabel(new TranslatableMarkup('Show website link'))
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
-    $fields['highlights'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Highlights'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+
     $fields['ontologyword_ids'] = BaseFieldDefinition::create('integer')
       ->setLabel(new TranslatableMarkup('Ontologyword IDs'))
       ->setTranslatable(FALSE)
@@ -344,46 +326,46 @@ class Unit extends TprEntityBase {
       ->setDisplayOptions('form', [
         'region' => 'hidden',
       ]);
-    $fields['other_info'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Further information'))
-      ->setDescription(new TranslatableMarkup('The "OTHER_INFO" connection type'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ]);
-    $fields['price_info'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Charges'))
-      ->setDescription(new TranslatableMarkup('The "PRICE" connection type'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ]);
-    $fields['links'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Web sites'))
-      ->setDescription(new TranslatableMarkup('The "LINK" connection type'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
-    $fields['contacts'] = BaseFieldDefinition::create('tpr_connection')
-      ->setLabel(new TranslatableMarkup('Other contact information'))
-      ->setDescription(new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'))
-      ->setTranslatable(TRUE)
-      ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
-      ->setDisplayOptions('form', [
-        'type' => 'readonly_field_widget',
-      ])
-      ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+
+    $connectionFields = [
+      'links' => [
+        'description' => new TranslatableMarkup('The "LINK" connection type'),
+        'label' => new TranslatableMarkup('Web sites'),
+      ],
+      'opening_hours' => [
+        'description' => new TranslatableMarkup('The "OPENING_HOURS" connection type'),
+        'label' => new TranslatableMarkup('Opening hours'),
+      ],
+      'highlights' => [
+        'description' => new TranslatableMarkup('The "HIGHLIGHTS" connection type'),
+        'label' => new TranslatableMarkup('Highlights'),
+      ],
+      'other_info' => [
+        'description' => new TranslatableMarkup('The "OTHER_INFO" connection type'),
+        'label' => new TranslatableMarkup('Further information'),
+      ],
+      'price_info' => [
+        'description' => new TranslatableMarkup('The "PRICE" connection type'),
+        'label' => new TranslatableMarkup('Charges'),
+      ],
+      'contacts' => [
+        'description' => new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'),
+        'label' => new TranslatableMarkup('Other contact information'),
+      ],
+     ];
+
+    foreach ($connectionFields as $name => $data) {
+      $fields[$name] = BaseFieldDefinition::create('tpr_connection')
+       ->setLabel($data['label'])
+       ->setDescription($data['description'])
+       ->setTranslatable(TRUE)
+       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
+       ->setDisplayOptions('form', [
+         'type' => 'readonly_field_widget',
+       ])
+       ->setDisplayConfigurable('form', TRUE)
+       ->setDisplayConfigurable('view', TRUE);
+    }
 
     return $fields;
   }

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -329,35 +329,35 @@ class Unit extends TprEntityBase {
 
     $connectionFields = [
       'links' => [
-        'description' => new TranslatableMarkup('The "LINK" connection type'),
-        'label' => new TranslatableMarkup('Web sites'),
+        'description' => 'The "LINK" connection type',
+        'label' => 'Web sites',
       ],
       'opening_hours' => [
-        'description' => new TranslatableMarkup('The "OPENING_HOURS" connection type'),
-        'label' => new TranslatableMarkup('Opening hours'),
+        'description' => 'The "OPENING_HOURS" connection type',
+        'label' => 'Opening hours',
       ],
       'highlights' => [
-        'description' => new TranslatableMarkup('The "HIGHLIGHTS" connection type'),
-        'label' => new TranslatableMarkup('Highlights'),
+        'description' => 'The "HIGHLIGHTS" connection type',
+        'label' => 'Highlights',
       ],
       'other_info' => [
-        'description' => new TranslatableMarkup('The "OTHER_INFO" connection type'),
-        'label' => new TranslatableMarkup('Further information'),
+        'description' => 'The "OTHER_INFO" connection type',
+        'label' => 'Further information',
       ],
       'price_info' => [
-        'description' => new TranslatableMarkup('The "PRICE" connection type'),
-        'label' => new TranslatableMarkup('Charges'),
+        'description' => 'The "PRICE" connection type',
+        'label' => 'Charges',
       ],
       'contacts' => [
-        'description' => new TranslatableMarkup('The "PHONE_OR_EMAIL" connection type'),
-        'label' => new TranslatableMarkup('Other contact information'),
+        'description' => 'The "PHONE_OR_EMAIL" connection type',
+        'label' => 'Other contact information',
       ],
     ];
 
     foreach ($connectionFields as $name => $data) {
       $fields[$name] = BaseFieldDefinition::create('tpr_connection')
-        ->setLabel($data['label'])
-        ->setDescription($data['description'])
+        ->setLabel(new TranslatableMarkup($data['label']))
+        ->setDescription(new TranslatableMarkup($data['description']))
         ->setTranslatable(TRUE)
         ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
         ->setDisplayOptions('form', [


### PR DESCRIPTION
## Why?
SonarCloud Quality Gate fails because of duplicated code.

## What was done
Refactored the code to reduce duplicated code.

## How to install

* Make sure your `kuva` instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi TPR config
    * `composer require drupal/helfi_tpr:dev-UHF-8595_fix-duplicate-code`
* Run `make drush-updb drush-cr drush-locale-update`
* Run the migration `drush migrate:import tpr_unit --idlist 41047:fi,41047:sv,41047:en --update`

## How to test

- [ ] Check https://helfi-kuva.docker.so/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/uimarannat/maauimalat/uimastadion and see that the charges, other information, web sites and other contacts fields are visible and have correct titles with correct translations.
- [ ] Code follows our standards.