### PR TITLE
UHF-8717: Added hide_service_points checkbox field to tpr_service.

### DIFF
--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -281,3 +281,20 @@ function helfi_tpr_update_8044() : void {
       ->installFieldStorageDefinition($name, 'tpr_unit', 'helfi_tpr', $field);
   }
 }
+
+/**
+ * Add a field for hiding the service points.
+ */
+function helfi_tpr_update_8045() : void {
+  $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(new TranslatableMarkup('Hide service points'))
+    ->setDescription(new TranslatableMarkup('Hide automatic service units listing '))
+    ->setTranslatable(TRUE)
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_service', 'helfi_tpr', $field);
+  }
+}

--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -288,7 +288,7 @@ function helfi_tpr_update_8044() : void {
 function helfi_tpr_update_8045() : void {
   $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
     ->setLabel(new TranslatableMarkup('Hide service points'))
-    ->setDescription(new TranslatableMarkup('Hide automatic service units listing '))
+    ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
     ->setTranslatable(TRUE)
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE);

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -238,6 +238,13 @@ class Service extends TprEntityBase {
       ->setRevisionable(FALSE)
       ->setTranslatable(TRUE);
 
+    $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(new TranslatableMarkup('Hide service points'))
+      ->setDescription(new TranslatableMarkup('Hide automatic service units listing '))
+      ->setTranslatable(TRUE)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
     return $fields;
   }
 

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -240,7 +240,7 @@ class Service extends TprEntityBase {
 
     $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
       ->setLabel(new TranslatableMarkup('Hide service points'))
-      ->setDescription(new TranslatableMarkup('Hide automatic service units listing '))
+      ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
       ->setTranslatable(TRUE)
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -107,3 +107,9 @@ msgstr "Lähetä tekstiviesti"
 msgctxt "Service channel type verb"
 msgid "Send us a telefax"
 msgstr "Lähetä faksia"
+
+msgid "Hide service points"
+msgstr "Piilota palvelupaikkojen listaus"
+
+msgid "Hide automatic service units listing"
+msgstr "Piilota palvelupaikkojen automaattinen listaus"


### PR DESCRIPTION
# [UHF-8717](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8717)
A feature to hide service points is needed.

## What was done
- Added a checkbox field for hiding the service points.

## How to install

* Make sure your instance (any instance with tpr_service content) is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi TPR config
    * `composer require drupal/helfi_tpr:dev-UFH-8717_Hiding-service-points`
    * `composer require drupal/hdbt:dev-UHF-8717_Hiding-service-points`
    * `composer require drupal/helfi_platform_config:dev-UHF-8717_Hiding-service-points`
* Run `make drush-updb drush-cr drush-local-update`

## How to test

- [ ] Open a tpr service page that has a list of services in the bottom of the page. Go edit the page and see the new checkbox "Hide service points".
- [ ] Check that the translations for the checkbox label and description work (might need to change the UI language from the user's settings.).
- [ ] Check that code follows our standards.
- [ ] Check the other PRs.

## Other PRs
hdbt: https://github.com/City-of-Helsinki/drupal-hdbt/pull/771
platform_config: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/587

[UHF-8717]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ