### PR TITLE
UHF-9113: Drupal10 bug fixes

### DIFF
--- a/modules/helfi_address_search/helfi_address_search.module
+++ b/modules/helfi_address_search/helfi_address_search.module
@@ -48,21 +48,21 @@ function helfi_address_search_views_data_alter(array &$data): void {
  * Implements hook_views_pre_execute().
  */
 function helfi_address_search_views_pre_execute(ViewExecutable $view): void {
-  if (!isset($view->filter["address_search"])) {
+  if (!isset($view->filter['address_search'])) {
     return;
   }
 
   // Query all results as the sorting and paging is done with
   // AddressSearch::getSortedResultsByAddress().
-  $view->query->setLimit(NULL);
-  $view->query->setOffset(NULL);
+  $view->query->setLimit(0);
+  $view->query->setOffset(0);
 }
 
 /**
  * Implements hook_views_pre_render().
  */
 function helfi_address_search_views_pre_render(ViewExecutable $view): void {
-  if (isset($view->filter["address_search"])) {
+  if (isset($view->filter['address_search'])) {
     $view = AddressSearch::sortByAddress($view);
   }
 }


### PR DESCRIPTION
## What was done 
- Fixed the NULL types from `views_pre_execute` causing the `Cannot assign null to property Drupal\views\Plugin\views\query\QueryPluginBase:: of type int`.
   - See: https://www.hel.fi/fi/test-kasvatus-ja-koulutus/varhaiskasvatus/varhaiskasvatus-paivakodissa/etsi-kunnallisia-paivakoteja