### PR TITLE
UHF-X: Fix caching issue in address search

### DIFF
--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -90,6 +90,10 @@ class AddressSearch extends FilterPluginBase {
         (float) $result->_entity->get('latitude')->getString(),
         (float) $result->_entity->get('longitude')->getString());
 
+      // The entity should not be cached since it relies on high-cardinality
+      // user input.
+      $result->_entity->mergeCacheMaxAge(0);
+
       // Set the distance to computed field.
       $result->_entity->set('distance', $distances[$result->_entity->get('id')->getString()]);
     }


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Issue from #kuuma_linja: after-school activity search results contain cached distances.

## How to install

* Make sure your **KASKO** instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the TPR module
    * `composer require drupal/helfi_tpr:dev-UHF-X-address-search-caching`
* Make sure that your `settings.local.php` and `*.services.yml` do not override default cache settings.
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to [/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/etsi-iltapaivatoimintapaikkoja](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/etsi-iltapaivatoimintapaikkoja). The search results should not contain distances.
* [x] Search for an address in western Helsinki, for example: `Lauttasaarentie 10`. Search results should contain distances and they should be sorted correctly.
* [x] Search for an address in eastern Helsinki, for example: `Vuosaarentie 10`. Search results should contain distances and they should be sorted correctly.
* [x] Reload the page (to clear the address search). None of the results should contain the distance.
* [x] Check that code follows our standards
