### PR TITLE
UHF-9234: Multilingual street address search instead of search with current language

### DIFF
--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -15,7 +15,8 @@ use Drupal\views\Plugin\views\filter\FilterPluginBase;
 use Drupal\views\Plugin\views\pager\PagerPluginBase;
 use Drupal\views\ViewExecutable;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Promise\Utils;
 
 /**
  * Address search for sorting the results to show the nearest units first.
@@ -29,6 +30,8 @@ use GuzzleHttp\Exception\RequestException;
  * @ViewsFilter("address_search")
  */
 class AddressSearch extends FilterPluginBase {
+
+  const BASE_URL = 'https://api.hel.fi/servicemap/v2/';
 
   /**
    * Provide a simple textfield for street address.
@@ -131,34 +134,64 @@ class AddressSearch extends FilterPluginBase {
    *   Latitude and longitude coordinates in array, or empty array.
    */
   protected static function fetchAddressCoordinates(string $address): array {
-    $language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+    $currentLanguage = \Drupal::languageManager()
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
+
+    $langcodes = ['fi', 'sv'];
+    // Reorder langcodes for the result generation, set current first.
+    if ($langcodes[$currentLanguage]) {
+      $langcodes = array_unique(array_merge([$currentLanguage], $langcodes));
+    }
 
     $client = new Client([
-      'base_uri' => 'https://api.hel.fi/servicemap/v2/',
+      'base_uri' => self::BASE_URL,
     ]);
 
-    try {
-      $response = $client->get('search', [
+    foreach($langcodes as $langcode) {
+      $queries[$langcode] = [
         'query' => [
           'q' => $address,
           'type' => 'address',
           'page' => '1',
           'page_size' => '1',
-          'language' => $language,
+          'language' => $langcode,
           'municipality' => 'helsinki',
         ],
-      ]);
+      ];
     }
-    catch (RequestException $e) {
+
+    try {
+      $promises = [
+        'sv' => $client->getAsync('search', $queries['sv']),
+        'fi' => $client->getAsync('search', $queries['fi']),
+      ];
+      $responses = Utils::unwrap($promises);
+    } catch (ConnectException $e) {
+      \Drupal::logger('helfi_tpr')
+        ->error(
+          "After school activity search\'s coordinate search failed,
+         error code: {$e->getCode()}"
+        );
       return [];
     }
 
-    $addressSearchResult = Json::decode($response->getBody());
+    foreach($langcodes as $langcode) {
+      $response = $responses[$langcode];
+      $result = Json::decode($response->getBody());
 
-    if (
-      empty($addressSearchResult["results"][0]["location"]["coordinates"][1]) ||
-      empty($addressSearchResult["results"][0]["location"]["coordinates"][0])
-    ) {
+      if (
+        empty($result["results"][0]["location"]["coordinates"][1]) ||
+        empty($result["results"][0]["location"]["coordinates"][0])
+      ) {
+        continue;
+      }
+
+      $addressSearchResult = $result;
+      break;
+    }
+
+    if (!$addressSearchResult) {
       return [];
     }
 

--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -148,7 +148,7 @@ class AddressSearch extends FilterPluginBase {
       'base_uri' => self::BASE_URL,
     ]);
 
-    foreach($langcodes as $langcode) {
+    foreach ($langcodes as $langcode) {
       $queries[$langcode] = [
         'query' => [
           'q' => $address,
@@ -167,7 +167,8 @@ class AddressSearch extends FilterPluginBase {
         'fi' => $client->getAsync('search', $queries['fi']),
       ];
       $responses = Utils::unwrap($promises);
-    } catch (ConnectException $e) {
+    } 
+    catch (ConnectException $e) {
       \Drupal::logger('helfi_tpr')
         ->error(
           "After school activity search\'s coordinate search failed,
@@ -176,7 +177,7 @@ class AddressSearch extends FilterPluginBase {
       return [];
     }
 
-    foreach($langcodes as $langcode) {
+    foreach ($langcodes as $langcode) {
       $response = $responses[$langcode];
       $result = Json::decode($response->getBody());
 

--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -167,7 +167,7 @@ class AddressSearch extends FilterPluginBase {
         'fi' => $client->getAsync('search', $queries['fi']),
       ];
       $responses = Utils::unwrap($promises);
-    } 
+    }
     catch (ConnectException $e) {
       \Drupal::logger('helfi_tpr')
         ->error(

--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -192,7 +192,7 @@ class AddressSearch extends FilterPluginBase {
       break;
     }
 
-    if (!$addressSearchResult) {
+    if (!isset($addressSearchResult)) {
       return [];
     }
 


### PR DESCRIPTION
# [UHF-9234](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9234)
Allow using swedish street name on search field in finnish page vice versa

## How to install

* Make sure your instance is up and running on latest dev branch.
    * git pull origin dev
    * make fresh
* Update the Helfi-TPR
    * composer require drupal/helfi_tpr:dev-UHF-9234
* Run make drush-updb drush-cr


## How to test
- Go to [/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/iltapaivatoimintapaikat](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/perusopetus/aamu-ja-iltapaivatoiminta-kerhot-ja-harrastukset/iltapaivatoiminta/iltapaivatoimintapaikat)
- Change language to swedish and check out some street names
- Switch back to finnish and try searching based on the street names you saw on swedish side
  - You should get results while using swedish street name on finnish page
  - Cross referencing the results should yield pretty much the same result no matter the page language or search term language ("porvoonkatu 2" result should more or less match "borgågatan 2" results)
 

[UHF-9234]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ