### PR TITLE
Uhf x provided language whitescreen

### DIFF
--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -9,6 +9,7 @@ use CommerceGuys\Addressing\AddressFormat\FieldOverride;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Webmozart\Assert\Assert;
 
@@ -76,6 +77,8 @@ use Webmozart\Assert\Assert;
  * )
  */
 class Unit extends TprEntityBase {
+
+  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}
@@ -380,6 +383,34 @@ class Unit extends TprEntityBase {
     }
 
     return $fields;
+  }
+
+  /**
+   * Get comma separated list of provided language names.
+   *
+   * @return string
+   *   Comma separated list of language names.
+   */
+  public function getProvidedLanguagesNames(): string {
+    $provided_languages = $this->get('provided_languages');
+    if ($provided_languages->isEmpty()) {
+      return '';
+    }
+
+    $all_languages = $this->languageManager()->getStandardLanguageList();
+
+    $language_names = [];
+    foreach ($provided_languages as $provided_language) {
+      $langcode = $provided_language->getValue()['value'];
+      if (!isset($all_languages[$langcode])) {
+        continue;
+      }
+
+      $language = $all_languages[$langcode][0];
+      $language_names[] = $this->t($language);
+    }
+
+    return implode(', ', $language_names);
   }
 
 }

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -391,7 +391,7 @@ class Unit extends TprEntityBase {
    * @return string
    *   Comma separated list of language names.
    */
-  public function getProvidedLanguagesNames(): string {
+  public function getProvidedLanguageNames(): string {
     $provided_languages = $this->get('provided_languages');
     if ($provided_languages->isEmpty()) {
       return '';

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -407,6 +407,7 @@ class Unit extends TprEntityBase {
       }
 
       $language = $all_languages[$langcode][0];
+      // phpcs:ignore
       $language_names[] = $this->t($language);
     }
 

--- a/tests/src/Kernel/UnitEntityTest.php
+++ b/tests/src/Kernel/UnitEntityTest.php
@@ -29,6 +29,7 @@ class UnitEntityTest extends MigrationTestBase {
     $entity = Unit::create([
       'id' => $id,
       'name' => 'TPR Unit ' . $id,
+      'provided_languages' => ['fi', 'en', 'ar', 'this_is_clearly wrong'],
     ]);
     $entity->save();
 
@@ -47,6 +48,12 @@ class UnitEntityTest extends MigrationTestBase {
 
     $entity->delete();
     $this->assertNotEquals(NULL, Unit::load(1));
+  }
+
+  public function testProvidedLanguages() : void {
+    $entity = $this->getEntity(1);
+    $languages_name_list = $entity->getProvidedLanguagesNames();
+    $this->assertEquals('Finnish, English, Arabic');
   }
 
 }

--- a/tests/src/Kernel/UnitEntityTest.php
+++ b/tests/src/Kernel/UnitEntityTest.php
@@ -50,10 +50,14 @@ class UnitEntityTest extends MigrationTestBase {
     $this->assertNotEquals(NULL, Unit::load(1));
   }
 
+  /**
+   * Test provided languages.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
   public function testProvidedLanguages() : void {
     $entity = $this->getEntity(1);
-    $languages_name_list = $entity->getProvidedLanguagesNames();
-    $this->assertEquals('Finnish, English, Arabic');
+    $this->assertEquals('Finnish, English, Arabic', $entity->getProvidedLanguagesNames());
   }
 
 }

--- a/tests/src/Kernel/UnitEntityTest.php
+++ b/tests/src/Kernel/UnitEntityTest.php
@@ -57,7 +57,7 @@ class UnitEntityTest extends MigrationTestBase {
    */
   public function testProvidedLanguages() : void {
     $entity = $this->getEntity(1);
-    $this->assertEquals('Finnish, English, Arabic', $entity->getProvidedLanguagesNames());
+    $this->assertEquals('Finnish, English, Arabic', $entity->getProvidedLanguageNames());
   }
 
 }


### PR DESCRIPTION
If TPR-unit had any other provided language than fi, en or sv, the tpr unit page would whitescreen.

## What was done
- Removed the provided-language template with logic in it
- Moved the logic to TPR-entity
- Called the entity method to get list of translated language names


### How to reproduce
- Setup Strategia-site
- [Go to this page](https://helfi-strategia.docker.so/fi/paatoksenteko-ja-hallinto/business-helsinki), it should whitescreen 

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-X_provided_language_whitescreen`
* Update the TPR module
  * `composer require drupal/helfi_tpr:dev-UHF-X_provided_language_whitescreen`
* Run `make drush-cr`

## How to test

- [Go to this page](https://helfi-strategia.docker.so/fi/paatoksenteko-ja-hallinto/business-helsinki)
  - The page should render normally
  - "Palvelukieli"  should be visible with a comma separated list of languages 
  - (don't mind the translations of the language names. they need to be fixed separately.)