### PR TITLE
UHF-11379: Fix missing translations in TPR migrations

### DIFF
--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -305,8 +305,18 @@ function helfi_tpr_views_data_alter(&$data) : void {
 }
 
 /**
- * Implements hook_migrate_MIGRATION_ID_prepare_row().
+ * Implements hook_migrate_prepare_row().
  */
-function helfi_tpr_migrate_tpr_service_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
-  \Drupal::service('event_dispatcher')->dispatch(new MigrationPrepareRowEvent($row, $migration, $source));
+function helfi_tpr_migrate_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) : void {
+  // @todo: Remove this when prepare row event dispatch is merged.
+  // @see: https://www.drupal.org/node/2952291
+  if (in_array($migration->id(), [
+    'tpr_service',
+    'tpr_errand_service',
+    'tpr_unit',
+    'tpr_service_channel',
+  ])) {
+    \Drupal::service('event_dispatcher')
+      ->dispatch(new MigrationPrepareRowEvent($row, $migration, $source));
+  }
 }

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -14,9 +14,9 @@ use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
-use Drupal\migrate\Row;
-use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
 
 /**
  * Implements hook_theme().
@@ -308,8 +308,8 @@ function helfi_tpr_views_data_alter(&$data) : void {
  * Implements hook_migrate_prepare_row().
  */
 function helfi_tpr_migrate_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) : void {
-  // @todo: Remove this when prepare row event dispatch is merged.
-  // @see: https://www.drupal.org/node/2952291
+  // @todo Remove this when prepare row event dispatch is merged.
+  // @see https://www.drupal.org/node/2952291
   if (in_array($migration->id(), [
     'tpr_service',
     'tpr_errand_service',

--- a/helfi_tpr.module
+++ b/helfi_tpr.module
@@ -13,6 +13,10 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrateSourceInterface;
 
 /**
  * Implements hook_theme().
@@ -298,4 +302,11 @@ function helfi_tpr_views_data_alter(&$data) : void {
     ],
   ];
 
+}
+
+/**
+ * Implements hook_migrate_MIGRATION_ID_prepare_row().
+ */
+function helfi_tpr_migrate_tpr_service_prepare_row(Row $row, MigrateSourceInterface $source, MigrationInterface $migration) {
+  \Drupal::service('event_dispatcher')->dispatch(new MigrationPrepareRowEvent($row, $migration, $source));
 }

--- a/helfi_tpr.services.yml
+++ b/helfi_tpr.services.yml
@@ -1,4 +1,8 @@
 services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
   migration_fixture.tpr_unit:
     class: Drupal\helfi_tpr\Fixture\Unit
   migration_fixture.tpr_service:
@@ -14,3 +18,5 @@ services:
     arguments: ['@config.factory']
     tags:
       - { name: event_subscriber }
+
+  Drupal\helfi_tpr\EventSubscriber\MigrationPrepareRowSubscriber: ~

--- a/src/Event/MigrationPrepareRowEvent.php
+++ b/src/Event/MigrationPrepareRowEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_tpr\Event;
+
+use Drupal\Component\EventDispatcher\Event;
+use Drupal\migrate\Row;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\MigrateSourceInterface;
+
+class MigrationPrepareRowEvent extends Event {
+
+  /**
+   * Constructs a MigrationPrepareRowEvent object.
+   *
+   * @param \Drupal\migrate\Row $row
+   *   The row that is being prepared.
+   * @param \Drupal\migrate\Plugin\MigrationInterface $migration
+   *   The migration plugin.
+   * @param \Drupal\migrate\Plugin\MigrateSourceInterface $source
+   *   The migration source.
+   */
+  public function __construct(
+    public readonly Row $row,
+    public readonly MigrationInterface $migration,
+    public readonly MigrateSourceInterface $source,
+  ) {}
+
+}

--- a/src/Event/MigrationPrepareRowEvent.php
+++ b/src/Event/MigrationPrepareRowEvent.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Drupal\helfi_tpr\Event;
 
 use Drupal\Component\EventDispatcher\Event;
-use Drupal\migrate\Row;
-use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\MigrateSourceInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
 
+/**
+ * Wraps a prepare row event for event listeners.
+ */
 class MigrationPrepareRowEvent extends Event {
 
   /**

--- a/src/EventSubscriber/MigrationPrepareRowSubscriber.php
+++ b/src/EventSubscriber/MigrationPrepareRowSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_tpr\EventSubscriber;
 
+use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
@@ -47,8 +48,8 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
    */
   protected static function getEntityTypeId(MigrateDestinationInterface $plugin): string {
     $entity_type_id = NULL;
-    if (strpos($plugin->getPluginId(), $plugin::DERIVATIVE_SEPARATOR)) {
-      [, $entity_type_id] = explode($plugin::DERIVATIVE_SEPARATOR, $plugin->getPluginId(), 2);
+    if (strpos($plugin->getPluginId(), PluginBase::DERIVATIVE_SEPARATOR)) {
+      [, $entity_type_id] = explode(PluginBase::DERIVATIVE_SEPARATOR, $plugin->getPluginId(), 2);
     }
     return $entity_type_id;
   }

--- a/src/EventSubscriber/MigrationPrepareRowSubscriber.php
+++ b/src/EventSubscriber/MigrationPrepareRowSubscriber.php
@@ -7,8 +7,8 @@ namespace Drupal\helfi_tpr\EventSubscriber;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
-use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate\Plugin\MigrateDestinationInterface;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -16,6 +16,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
 
+  /**
+   * The migration IDs that are allowed to be processed.
+   *
+   * @var string[]
+   */
   private array $allowedMigrationIds = [
     'tpr_service',
     'tpr_errand_service',
@@ -34,8 +39,8 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
   /**
    * Get the entity type ID from a plugin ID.
    *
-   * @param string $plugin_id
-   *   The plugin ID.
+   * @param \Drupal\migrate\Plugin\MigrateDestinationInterface $plugin
+   *   The destinationplugin.
    *
    * @return string
    *   The entity type ID.
@@ -51,13 +56,15 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
   /**
    * Check if a mapping entry exists in the for the given source.
    *
-   * @param string $source_id
+   * @param int $source_id
    *   The source ID.
    * @param \Drupal\helfi_tpr\Event\MigrationPrepareRowEvent $event
    *   The migration prepare row event.
    */
   protected function hasExistingMapping(int $source_id, MigrationPrepareRowEvent $event): bool {
-    $table_name = $event->migration->getIdMap()->mapTableName();
+    /** @var \Drupal\migrate\Plugin\migrate\id_map\Sql $id_map */
+    $id_map = $event->migration->getIdMap();
+    $table_name = $id_map->mapTableName();
 
     $query = $this->connection
       ->select($table_name, 't')
@@ -71,7 +78,7 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
    *
    * @param string $entity_type_id
    *   The entity type ID.
-   * @param string $entity_id
+   * @param int $entity_id
    *   The entity ID.
    * @param string $langcode
    *   The language code.
@@ -145,7 +152,6 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
       $this->processPrepareRow($event);
     }
   }
-
 
   /**
    * {@inheritdoc}

--- a/src/EventSubscriber/MigrationPrepareRowSubscriber.php
+++ b/src/EventSubscriber/MigrationPrepareRowSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_tpr\EventSubscriber;
+
+use Drupal\Core\Database\Connection;
+use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for handling row preparation in TPR migration processes.
+ */
+final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
+
+  private array $allowedMigrationIds = [
+    'tpr_service',
+  ];
+
+  /**
+   * Constructs a MigrationPrepareRowSubscriber event subscriber.
+   */
+  public function __construct(
+    private readonly Connection $connection,
+  ) {}
+
+  /**
+   * Handles the migration prepare row event.
+   *
+   * @param \Drupal\helfi_tpr\Event\MigrationPrepareRowEvent $event
+   *   The migration prepare row event.
+   */
+  public function onPrepareRow(MigrationPrepareRowEvent $event): void {
+    if (!in_array($event->migration->id(), $this->allowedMigrationIds)) {
+      return;
+    }
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      MigrationPrepareRowEvent::class => ['onPrepareRow'],
+    ];
+  }
+
+}

--- a/src/EventSubscriber/MigrationPrepareRowSubscriber.php
+++ b/src/EventSubscriber/MigrationPrepareRowSubscriber.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Drupal\helfi_tpr\EventSubscriber;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate\Plugin\MigrateDestinationInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -22,7 +25,111 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
    */
   public function __construct(
     private readonly Connection $connection,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
   ) {}
+
+  /**
+   * Get the entity type ID from a plugin ID.
+   *
+   * @param string $plugin_id
+   *   The plugin ID.
+   *
+   * @return string
+   *   The entity type ID.
+   */
+  protected static function getEntityTypeId(MigrateDestinationInterface $plugin): string {
+    $entity_type_id = NULL;
+    if (strpos($plugin->getPluginId(), $plugin::DERIVATIVE_SEPARATOR)) {
+      [, $entity_type_id] = explode($plugin::DERIVATIVE_SEPARATOR, $plugin->getPluginId(), 2);
+    }
+    return $entity_type_id;
+  }
+
+  /**
+   * Check if a mapping entry exists in the for the given source.
+   *
+   * @param string $source_id
+   *   The source ID.
+   * @param \Drupal\helfi_tpr\Event\MigrationPrepareRowEvent $event
+   *   The migration prepare row event.
+   */
+  protected function hasExistingMapping(int $source_id, MigrationPrepareRowEvent $event): bool {
+    $table_name = $event->migration->getIdMap()->mapTableName();
+
+    $query = $this->connection
+      ->select($table_name, 't')
+      ->condition('t.sourceid1', $source_id);
+
+    return (bool) $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * Check if an entity exists in the database.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string $entity_id
+   *   The entity ID.
+   * @param string $langcode
+   *   The language code.
+   */
+  protected function entityExists(string $entity_type_id, int $entity_id, string $langcode): bool {
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
+
+    // Do a database query since we do not need to load entity fields.
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('id', $entity_id)
+      ->condition('langcode', $langcode)
+      ->range(0, 1)
+      ->execute();
+
+    return !empty($ids);
+  }
+
+  /**
+   * Process the prepare row event of TPR migrations.
+   *
+   * This ensures that any missing translations are marked for force import
+   * in any cases where we have records in the mapping table but the entity
+   * does not exist in the database.
+   *
+   * @param \Drupal\helfi_tpr\Event\MigrationPrepareRowEvent $event
+   *   The migration prepare row event.
+   */
+  protected function processPrepareRow(MigrationPrepareRowEvent $event): void {
+    $row = $event->row;
+
+    if (!$row || $row->isStub()) {
+      return;
+    }
+
+    // Get the entity type ID from the plugin.
+    $plugin = $event->migration->getDestinationPlugin();
+    $entity_type_id = static::getEntityTypeId($plugin);
+
+    // Skip if we could not determine the entity type.
+    if (!$entity_type_id) {
+      return;
+    }
+
+    // Skip if the entity has not been migrated yet and let the migration
+    // normally handle the creation of the entity.
+    if (!$this->hasExistingMapping($row->getSourceProperty('id'), $event)) {
+      return;
+    }
+
+    // If we have records in the mapping table but the entity does not exist,
+    // mark the row for force import.
+    if (!$this->entityExists($entity_type_id, $row->getSourceProperty('id'), $row->getSourceProperty('language'))) {
+      $id_map = $row->getIdMap();
+
+      // Force update or create if the destination entity does not exist.
+      $id_map['source_row_status'] = MigrateIdMapInterface::STATUS_NEEDS_UPDATE;
+      $row->setIdMap($id_map);
+    }
+
+  }
 
   /**
    * Handles the migration prepare row event.
@@ -31,8 +138,8 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
    *   The migration prepare row event.
    */
   public function onPrepareRow(MigrationPrepareRowEvent $event): void {
-    if (!in_array($event->migration->id(), $this->allowedMigrationIds)) {
-      return;
+    if (in_array($event->migration->id(), $this->allowedMigrationIds)) {
+      $this->processPrepareRow($event);
     }
   }
 

--- a/src/EventSubscriber/MigrationPrepareRowSubscriber.php
+++ b/src/EventSubscriber/MigrationPrepareRowSubscriber.php
@@ -18,6 +18,9 @@ final class MigrationPrepareRowSubscriber implements EventSubscriberInterface {
 
   private array $allowedMigrationIds = [
     'tpr_service',
+    'tpr_errand_service',
+    'tpr_unit',
+    'tpr_service_channel',
   ];
 
   /**

--- a/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
+++ b/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
@@ -75,9 +75,6 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
 
   /**
    * Tests that the missing entity translation is marked for migration import.
-   *
-   * @covers ::processPrepareRow
-   * @covers ::__construct
    */
   public function testMissingEntityTranslation(): void {
     // Initialise the row with a status of imported.
@@ -108,9 +105,6 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
 
   /**
    * Test that the row status is not updated if the entity translation exists.
-   *
-   * @covers ::processPrepareRow
-   * @covers ::__construct
    */
   public function testExistingEntityTranslation(): void {
     // Initialise the row with a status of imported.

--- a/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
+++ b/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_tpr\Kernel;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Select;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\migrate\Row;
+use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
+use Drupal\helfi_tpr\EventSubscriber\MigrationPrepareRowSubscriber;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\Core\Database\StatementInterface;
+use Prophecy\Argument;
+
+/**
+ * Tests the TPR migration prepare row subscriber.
+ *
+ * @group helfi_tpr
+ */
+class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['remote_entity_test'];
+
+  /**
+   * Creates a mock database connection that expects a mapping to exist.
+   */
+  protected function mockDatabaseConnection(bool $mappingExists = true): Connection {
+    $statement = $this->prophesize(StatementInterface::class);
+    $statement->fetchField()->willReturn($mappingExists ? 1 : 0);
+
+    $select = $this->prophesize(Select::class);
+    $select->condition(Argument::any(), Argument::any())->willReturn($select);
+    $select->countQuery()->willReturn($select);
+    $select->execute()->willReturn($statement->reveal());
+
+    $connection = $this->prophesize(Connection::class);
+    $connection->select(Argument::any(), Argument::any())
+      ->willReturn($select->reveal());
+
+    return $connection->reveal();
+  }
+
+  /**
+   * Creates a mock entity storage that can simulate entity translation existence.
+   */
+  protected function mockEntityStorage(bool $translationExists = false): EntityStorageInterface {
+    $query = $this->prophesize(QueryInterface::class);
+    $query->accessCheck(Argument::any())->willReturn($query);
+    $query->condition(Argument::any(), Argument::any())->willReturn($query);
+    $query->range(Argument::any(), Argument::any())->willReturn($query);
+    $query->execute()->willReturn($translationExists ? ['1' => '1'] : []);
+
+    $storage = $this->prophesize(EntityStorageInterface::class);
+    $storage->getQuery()->willReturn($query->reveal());
+
+    return $storage->reveal();
+  }
+
+  /**
+   * Creates a mock entity type manager.
+   */
+  protected function mockEntityTypeManager(EntityStorageInterface $storage): EntityTypeManagerInterface {
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage(Argument::any())->willReturn($storage);
+
+    return $entityTypeManager->reveal();
+  }
+
+  /**
+   * Tests that the missing entity translation is marked for migration import.
+   *
+   * @covers ::processPrepareRow
+   * @covers ::__construct
+   */
+  public function testMissingEntityTranslation(): void {
+    // Initialise the row with a status of imported.
+    $row = new Row(['id' => 1, 'language' => 'en'], ['id' => []]);
+    $row->setIdMap(['source_row_status' => MigrateIdMapInterface::STATUS_IMPORTED]);
+
+    $migration = $this->getMigration('tpr_service');
+    $source = $migration->getSourcePlugin();
+
+    // Mock the database with the state that the mapping exists.
+    $connection = $this->mockDatabaseConnection(true);
+
+    // Mock the entity storage to indicate that the entity translation does not exist.
+    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(false));
+
+    $event = new MigrationPrepareRowEvent($row, $migration, $source);
+
+    $sut = new MigrationPrepareRowSubscriber($connection, $entityTypeManager);
+    $sut->onPrepareRow($event);
+
+    // Assert that the row status is set to needs update.
+    $this->assertEquals(
+      MigrateIdMapInterface::STATUS_NEEDS_UPDATE,
+      $row->getIdMap()['source_row_status']
+    );
+  }
+
+  /**
+   * Test that the row status is not updated if the entity translation exists.
+   *
+   * @covers ::processPrepareRow
+   * @covers ::__construct
+   */
+  public function testExistingEntityTranslation(): void {
+    // Initialise the row with a status of imported.
+    $row = new Row(['id' => 1, 'language' => 'en'], ['id' => []]);
+    $row->setIdMap(['source_row_status' => MigrateIdMapInterface::STATUS_IMPORTED]);
+
+    $migration = $this->getMigration('tpr_service');
+    $source = $migration->getSourcePlugin();
+
+    // Mock the database with the state that the mapping exists.
+    $connection = $this->mockDatabaseConnection(true);
+
+    // Mock the entity storage to indicate that the entity translation exists.
+    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(true));
+
+    $event = new MigrationPrepareRowEvent($row, $migration, $source);
+
+    $sut = new MigrationPrepareRowSubscriber($connection, $entityTypeManager);
+    $sut->onPrepareRow($event);
+
+    // Assert that the row status is not updated.
+    $this->assertEquals(
+      MigrateIdMapInterface::STATUS_IMPORTED,
+      $row->getIdMap()['source_row_status']
+    );
+  }
+
+}

--- a/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
+++ b/tests/src/Kernel/MigrationPrepareRowSubscriberTest.php
@@ -6,14 +6,14 @@ namespace Drupal\Tests\helfi_tpr\Kernel;
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\Select;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Database\StatementInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
-use Drupal\migrate\Row;
 use Drupal\helfi_tpr\Event\MigrationPrepareRowEvent;
 use Drupal\helfi_tpr\EventSubscriber\MigrationPrepareRowSubscriber;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
-use Drupal\Core\Database\StatementInterface;
+use Drupal\migrate\Row;
 use Prophecy\Argument;
 
 /**
@@ -31,7 +31,7 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
   /**
    * Creates a mock database connection that expects a mapping to exist.
    */
-  protected function mockDatabaseConnection(bool $mappingExists = true): Connection {
+  protected function mockDatabaseConnection(bool $mappingExists = TRUE): Connection {
     $statement = $this->prophesize(StatementInterface::class);
     $statement->fetchField()->willReturn($mappingExists ? 1 : 0);
 
@@ -48,9 +48,9 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
   }
 
   /**
-   * Creates a mock entity storage that can simulate entity translation existence.
+   * Creates a mock entity storage that can simulate translation existence.
    */
-  protected function mockEntityStorage(bool $translationExists = false): EntityStorageInterface {
+  protected function mockEntityStorage(bool $translationExists = FALSE): EntityStorageInterface {
     $query = $this->prophesize(QueryInterface::class);
     $query->accessCheck(Argument::any())->willReturn($query);
     $query->condition(Argument::any(), Argument::any())->willReturn($query);
@@ -88,10 +88,11 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
     $source = $migration->getSourcePlugin();
 
     // Mock the database with the state that the mapping exists.
-    $connection = $this->mockDatabaseConnection(true);
+    $connection = $this->mockDatabaseConnection(TRUE);
 
-    // Mock the entity storage to indicate that the entity translation does not exist.
-    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(false));
+    // Mock the entity storage indicating that the entity
+    // translation does not exist.
+    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(FALSE));
 
     $event = new MigrationPrepareRowEvent($row, $migration, $source);
 
@@ -120,10 +121,10 @@ class MigrationPrepareRowSubscriberTest extends MigrationTestBase {
     $source = $migration->getSourcePlugin();
 
     // Mock the database with the state that the mapping exists.
-    $connection = $this->mockDatabaseConnection(true);
+    $connection = $this->mockDatabaseConnection(TRUE);
 
     // Mock the entity storage to indicate that the entity translation exists.
-    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(true));
+    $entityTypeManager = $this->mockEntityTypeManager($this->mockEntityStorage(TRUE));
 
     $event = new MigrationPrepareRowEvent($row, $migration, $source);
 


### PR DESCRIPTION
# [UHF-11379](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11379)

## What was done

* Fix the issue where TPR translations are not migrated

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi TPR module
  * `composer require drupal/helfi_tpr:dev-UHF-11379`
* Run `make drush-updb drush-cr`

## How to test

* [x] Temporarily remove the following lines to be able to delete TPR services: https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/blob/main/src/Entity/Form/TprDeleteForm.php#L53-L58
* [x] Delete one of the TPR service's translation
* [x] Run the migration
* [x] Migration should re-import the missing translation and report that one item has been updated


[UHF-11379]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ