### PR TITLE
UHF-11682: fix warning

### DIFF
--- a/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
+++ b/modules/helfi_address_search/src/Plugin/views/filter/AddressSearch.php
@@ -172,7 +172,7 @@ class AddressSearch extends FilterPluginBase {
       \Drupal::logger('helfi_tpr')
         ->error(
           "After school activity search\'s coordinate search failed,
-         error code: {$e->getCode()}"
+         message: {$e->getMessage()}"
         );
       return [];
     }


### PR DESCRIPTION
Fix: Warning: Undefined array key "fi" in Drupal\\helfi_address_search\\Plugin\\views\\filter\\AddressSearch::fetchAddressCoordinates()

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards