### PR TITLE
UHF-12075 Remove errand service canonical route

### DIFF
--- a/src/Entity/ErrandService.php
+++ b/src/Entity/ErrandService.php
@@ -52,7 +52,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
  *     "revision_log_message" = "revision_log"
  *   },
  *   links = {
- *     "canonical" = "/tpr-errand-service/{tpr_errand_service}",
  *     "edit-form" = "/admin/content/integrations/tpr-errand-service/{tpr_errand_service}/edit",
  *     "collection" = "/admin/content/integrations/tpr-errand-service",
  *     "delete-form" = "/admin/content/integrations/tpr-errand-service/{tpr_errand_service}/delete",


### PR DESCRIPTION
Check the [hdbt-pr](https://github.com/City-of-Helsinki/drupal-hdbt/pull/1349)

Users aren't supposed to be able to enter the entity's view route.